### PR TITLE
bindgen: format builder error message into bindgen error

### DIFF
--- a/wgsl_bindgen/src/wgsl_bindgen.rs
+++ b/wgsl_bindgen/src/wgsl_bindgen.rs
@@ -25,7 +25,7 @@ const PKG_NAME: &str = env!("CARGO_PKG_NAME");
 /// in `wgsl_bindgen`.
 #[derive(Debug, Error, Diagnostic)]
 pub enum WgslBindgenError {
-  #[error("All required fields need to be set upfront")]
+  #[error("All required fields need to be set upfront: {0}")]
   OptionBuilderError(#[from] WgslBindgenOptionBuilderError),
 
   #[error(transparent)]


### PR DESCRIPTION
Include the builder error message in the formatted error of bindgen. This changes from:

```
Error: Diagnostic { message: "All required fields need to be set upfront" }
```

To:

```
Error: Diagnostic { message: "All required fields need to be set upfront: `wgsl_type_map` must be initialized" }
```