### PR TITLE
Allow capabilities

### DIFF
--- a/wgsl_bindgen/src/lib.rs
+++ b/wgsl_bindgen/src/lib.rs
@@ -67,6 +67,7 @@ mod wgsl_type;
 pub use types::*;
 pub use wgsl_bindgen::*;
 pub use wgsl_type::*;
+pub use naga::valid::Capabilities;
 
 /// Enum representing the possible serialization strategies for WGSL types.
 ///
@@ -577,7 +578,7 @@ mod test {
                             })
                     }
                     const SHADER_STRING: &'static str = r#"
-                @fragment 
+                @fragment
                 fn fs_main() {
                     return;
                 }

--- a/wgsl_bindgen/src/wgsl_bindgen.rs
+++ b/wgsl_bindgen/src/wgsl_bindgen.rs
@@ -137,7 +137,7 @@ pub struct WgslBindgenOption {
   pub additional_scan_dirs: Vec<AdditionalScanDirectory>,
 
   #[builder(default)]
-  pub capabilities: naga::valid::Capabilities,
+  pub capabilities: crate::Capabilities,
 }
 
 impl WgslBindgenOptionBuilder {
@@ -213,7 +213,7 @@ impl WGSLBindgen {
   }
 
   fn generate_naga_module_for_entry(
-    capabilities: naga::valid::Capabilities,
+    capabilities: crate::Capabilities,
     entry: SourceWithFullDependenciesResult<'_>,
   ) -> Result<WgslEntryResult, WgslBindgenError> {
     let map_err = |err: ComposerError| WgslBindgenError::NagaModuleComposeError {

--- a/wgsl_bindgen/src/wgsl_bindgen.rs
+++ b/wgsl_bindgen/src/wgsl_bindgen.rs
@@ -135,6 +135,9 @@ pub struct WgslBindgenOption {
   /// The additional set of directories to scan for source files.
   #[builder(default, setter(into, each(name = "additional_scan_dir", into)))]
   pub additional_scan_dirs: Vec<AdditionalScanDirectory>,
+
+  #[builder(default)]
+  pub capabilities: naga::valid::Capabilities,
 }
 
 impl WgslBindgenOptionBuilder {
@@ -210,6 +213,7 @@ impl WGSLBindgen {
   }
 
   fn generate_naga_module_for_entry(
+    capabilities: naga::valid::Capabilities,
     entry: SourceWithFullDependenciesResult<'_>,
   ) -> Result<WgslEntryResult, WgslBindgenError> {
     let map_err = |err: ComposerError| WgslBindgenError::NagaModuleComposeError {
@@ -217,7 +221,7 @@ impl WGSLBindgen {
       inner: err.inner,
     };
 
-    let mut composer = Composer::default();
+    let mut composer = Composer::default().with_capabilities(capabilities);
     let source = entry.source_file;
 
     for dependency in entry.full_dependencies.iter() {
@@ -249,11 +253,12 @@ impl WGSLBindgen {
 
   pub fn generate_string(&self) -> Result<String, WgslBindgenError> {
     use std::fmt::Write;
+    let capabilities = self.options.capabilities;
     let entry_results = self
       .dependency_tree
       .get_source_files_with_full_dependencies()
       .into_iter()
-      .map(Self::generate_naga_module_for_entry)
+      .map(|it| Self::generate_naga_module_for_entry(capabilities, it))
       .collect::<Result<Vec<_>, _>>()?;
 
     let mut text = String::new();


### PR DESCRIPTION
Currently wgsl-bindgen use default setting for Composer, this patch provide user the option to set the capabilities they want.

Some capabilities (such as PUSH_CONSTANT) are quit useful, and user may want to enable it.