### PR TITLE
Make SHADER_STRING public

### DIFF
--- a/example/src/shader_bindings.rs
+++ b/example/src/shader_bindings.rs
@@ -934,7 +934,7 @@ pub mod testbed {
                 source: wgpu::ShaderSource::Wgsl(source),
             })
     }
-    const SHADER_STRING: &'static str = r#"
+    pub const SHADER_STRING: &'static str = r#"
 struct rtsStructX_naga_oil_mod_XEIXC4LZOFYXW233SMUWXG2DBMRSXELLGNFWGK4ZPOJSWCY3INVSSEX {
     other_data: i32,
     the_array: array<u32>,
@@ -1416,7 +1416,7 @@ pub mod triangle {
                 source: wgpu::ShaderSource::Wgsl(source),
             })
     }
-    const SHADER_STRING: &'static str = r#"
+    pub const SHADER_STRING: &'static str = r#"
 struct Uniforms {
     color_rgb: vec4<f32>,
 }

--- a/wgsl_bindgen/src/generate/shader_module.rs
+++ b/wgsl_bindgen/src/generate/shader_module.rs
@@ -275,7 +275,7 @@ fn generate_shader_module_embedded(entry: &WgslEntryResult) -> TokenStream {
           })
       }
   };
-  let shader_str_def = quote!(const SHADER_STRING: &'static str = #shader_literal;);
+  let shader_str_def = quote!(pub const SHADER_STRING: &'static str = #shader_literal;);
 
   quote! {
     #create_shader_module

--- a/wgsl_bindgen/src/lib.rs
+++ b/wgsl_bindgen/src/lib.rs
@@ -444,7 +444,7 @@ mod test {
                                 source: wgpu::ShaderSource::Wgsl(source),
                             })
                     }
-                    const SHADER_STRING: &'static str = r#"
+                    pub const SHADER_STRING: &'static str = r#"
                 @fragment 
                 fn fs_main() {
                     return;

--- a/wgsl_bindgen/tests/output/bindgen_bevy.expected.rs
+++ b/wgsl_bindgen/tests/output/bindgen_bevy.expected.rs
@@ -1062,7 +1062,7 @@ pub mod pbr {
                 source: wgpu::ShaderSource::Wgsl(source),
             })
     }
-    const SHADER_STRING: &'static str = r#"
+    pub const SHADER_STRING: &'static str = r#"
 struct MeshVertexOutputX_naga_oil_mod_XMJSXM6K7OBRHEOR2NVSXG2C7OZSXE5DFPBPW65LUOB2XIX {
     @location(0) world_position: vec4<f32>,
     @location(1) world_normal: vec3<f32>,

--- a/wgsl_bindgen/tests/output/bindgen_main.expected.rs
+++ b/wgsl_bindgen/tests/output/bindgen_main.expected.rs
@@ -306,7 +306,7 @@ pub mod main {
                 source: wgpu::ShaderSource::Wgsl(source),
             })
     }
-    const SHADER_STRING: &'static str = r#"
+    pub const SHADER_STRING: &'static str = r#"
 struct Style {
     color: vec4<f32>,
     width: f32,

--- a/wgsl_bindgen/tests/output/bindgen_minimal.expected.rs
+++ b/wgsl_bindgen/tests/output/bindgen_minimal.expected.rs
@@ -203,7 +203,7 @@ pub mod minimal {
                 source: wgpu::ShaderSource::Wgsl(source),
             })
     }
-    const SHADER_STRING: &'static str = r#"
+    pub const SHADER_STRING: &'static str = r#"
 struct Uniforms {
     color: vec4<f32>,
     width: f32,

--- a/wgsl_bindgen/tests/output/bindgen_padding.expected.rs
+++ b/wgsl_bindgen/tests/output/bindgen_padding.expected.rs
@@ -208,7 +208,7 @@ pub mod padding {
                 source: wgpu::ShaderSource::Wgsl(source),
             })
     }
-    const SHADER_STRING: &'static str = r#"
+    pub const SHADER_STRING: &'static str = r#"
 struct Style {
     color: vec4<f32>,
     width: f32,


### PR DESCRIPTION
When using wgsl_bindgen with an existing WGPU codebase, it can be nice to have access to the SHADER_STRING. Eg. for my usecase, I'm using it to write some custom kernels for a project using [burn](https://github.com/tracel-ai/burn), where I just need the handle imports, generate some struct bindings, and get the final processed shader file. See issue #12.

I've updated the unit tests as far as I'm aware BUT, I can't t test this properly. Atm the tests firstly fail on:

```
---- bevy_util::name_demangle::tests::test_demangle_mod_names stdout ----
thread 'bevy_util::name_demangle::tests::test_demangle_mod_names' panicked at wgsl_bindgen\src\bevy_util\name_demangle.rs:101:5:
assertion failed: `(left == right)`

Diff < left / right > :
 RustItemPath {
<    parent_module_path: ":types",
>    parent_module_path: "s::types",
     item_name: "SnehaData",
 }
```

Fixing that error still leaves a bunch of errors, as macOS and Windows generated files don't match atm (newlines, and different path seperators). I've tried fixing those first but that seems to be a bit more invovled, let me know if you'd like to fix that / for me to create some PRs / ... 

Thanks for having a look!