### PR TITLE
Bind group entries refactor

### DIFF
--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -27,8 +27,8 @@ struct State {
     size: winit::dpi::PhysicalSize<u32>,
     config: wgpu::SurfaceConfiguration,
     pipeline: wgpu::RenderPipeline,
-    bind_group0: shader_bindings::triangle::bind_groups::WgpuBindGroup0,
-    bind_group1: shader_bindings::triangle::bind_groups::WgpuBindGroup1,
+    bind_group0: shader_bindings::triangle::WgpuBindGroup0,
+    bind_group1: shader_bindings::triangle::WgpuBindGroup1,
     vertex_buffer: wgpu::Buffer,
 }
 
@@ -145,12 +145,14 @@ impl State {
         });
 
         // Use the generated types to ensure the correct bind group is assigned to each slot.
-        let bind_group0 = shader_bindings::triangle::bind_groups::WgpuBindGroup0::from_bindings(
+        let bind_group0 = shader_bindings::triangle::WgpuBindGroup0::from_bindings(
             &device,
-            shader_bindings::triangle::bind_groups::WgpuBindGroupLayout0 {
-                color_texture: &view,
-                color_sampler: &sampler,
-            },
+            shader_bindings::triangle::WgpuBindGroup0EntryCollection::new(
+                shader_bindings::triangle::WgpuBindGroup0EntryCollectionParams {
+                    color_texture: &view,
+                    color_sampler: &sampler,
+                },
+            ),
         );
 
         let uniforms_buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
@@ -161,11 +163,13 @@ impl State {
             usage: wgpu::BufferUsages::UNIFORM,
         });
 
-        let bind_group1 = shader_bindings::triangle::bind_groups::WgpuBindGroup1::from_bindings(
+        let bind_group1 = shader_bindings::triangle::WgpuBindGroup1::from_bindings(
             &device,
-            shader_bindings::triangle::bind_groups::WgpuBindGroupLayout1 {
-                uniforms: uniforms_buffer.as_entire_buffer_binding(),
-            },
+            shader_bindings::triangle::WgpuBindGroup1EntryCollection::new(
+                shader_bindings::triangle::WgpuBindGroup1EntryCollectionParams {
+                    uniforms: uniforms_buffer.as_entire_buffer_binding(),
+                },
+            ),
         );
 
         // Initialize the vertex buffer based on the expected input structs.

--- a/example/src/shader_bindings.rs
+++ b/example/src/shader_bindings.rs
@@ -514,22 +514,32 @@ pub mod testbed {
     pub mod bind_groups {
         use super::{_root, _root::*};
         #[derive(Debug)]
-        pub struct WgpuBindGroupLayout0<'a> {
+        pub struct WgpuBindGroup0EntryCollectionParams<'a> {
             pub color_texture: &'a wgpu::TextureView,
             pub color_sampler: &'a wgpu::Sampler,
         }
-        impl<'a> WgpuBindGroupLayout0<'a> {
-            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 2] {
-                [
-                    wgpu::BindGroupEntry {
+        #[derive(Debug)]
+        pub struct WgpuBindGroup0EntryCollection<'a> {
+            pub color_texture: wgpu::BindGroupEntry<'a>,
+            pub color_sampler: wgpu::BindGroupEntry<'a>,
+        }
+        impl<'a> WgpuBindGroup0EntryCollection<'a> {
+            pub fn new(params: WgpuBindGroup0EntryCollectionParams<'a>) -> Self {
+                Self {
+                    color_texture: wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::TextureView(self.color_texture),
+                        resource: wgpu::BindingResource::TextureView(
+                            params.color_texture,
+                        ),
                     },
-                    wgpu::BindGroupEntry {
+                    color_sampler: wgpu::BindGroupEntry {
                         binding: 1,
-                        resource: wgpu::BindingResource::Sampler(self.color_sampler),
+                        resource: wgpu::BindingResource::Sampler(params.color_sampler),
                     },
-                ]
+                }
+            }
+            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 2] {
+                [self.color_texture, self.color_sampler]
             }
         }
         #[derive(Debug)]
@@ -569,7 +579,7 @@ pub mod testbed {
             }
             pub fn from_bindings(
                 device: &wgpu::Device,
-                bindings: WgpuBindGroupLayout0,
+                bindings: WgpuBindGroup0EntryCollection,
             ) -> Self {
                 let bind_group_layout = Self::get_bind_group_layout(&device);
                 let entries = bindings.entries();
@@ -588,17 +598,24 @@ pub mod testbed {
             }
         }
         #[derive(Debug)]
-        pub struct WgpuBindGroupLayout1<'a> {
+        pub struct WgpuBindGroup1EntryCollectionParams<'a> {
             pub uniforms: wgpu::BufferBinding<'a>,
         }
-        impl<'a> WgpuBindGroupLayout1<'a> {
-            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 1] {
-                [
-                    wgpu::BindGroupEntry {
+        #[derive(Debug)]
+        pub struct WgpuBindGroup1EntryCollection<'a> {
+            pub uniforms: wgpu::BindGroupEntry<'a>,
+        }
+        impl<'a> WgpuBindGroup1EntryCollection<'a> {
+            pub fn new(params: WgpuBindGroup1EntryCollectionParams<'a>) -> Self {
+                Self {
+                    uniforms: wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::Buffer(self.uniforms),
+                        resource: wgpu::BindingResource::Buffer(params.uniforms),
                     },
-                ]
+                }
+            }
+            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 1] {
+                [self.uniforms]
             }
         }
         #[derive(Debug)]
@@ -629,7 +646,7 @@ pub mod testbed {
             }
             pub fn from_bindings(
                 device: &wgpu::Device,
-                bindings: WgpuBindGroupLayout1,
+                bindings: WgpuBindGroup1EntryCollection,
             ) -> Self {
                 let bind_group_layout = Self::get_bind_group_layout(&device);
                 let entries = bindings.entries();
@@ -648,7 +665,7 @@ pub mod testbed {
             }
         }
         #[derive(Debug)]
-        pub struct WgpuBindGroupLayout2<'a> {
+        pub struct WgpuBindGroup2EntryCollectionParams<'a> {
             pub rts: wgpu::BufferBinding<'a>,
             pub a: wgpu::BufferBinding<'a>,
             pub b: wgpu::BufferBinding<'a>,
@@ -658,42 +675,56 @@ pub mod testbed {
             pub h: wgpu::BufferBinding<'a>,
             pub i: wgpu::BufferBinding<'a>,
         }
-        impl<'a> WgpuBindGroupLayout2<'a> {
-            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 8] {
-                [
-                    wgpu::BindGroupEntry {
+        #[derive(Debug)]
+        pub struct WgpuBindGroup2EntryCollection<'a> {
+            pub rts: wgpu::BindGroupEntry<'a>,
+            pub a: wgpu::BindGroupEntry<'a>,
+            pub b: wgpu::BindGroupEntry<'a>,
+            pub c: wgpu::BindGroupEntry<'a>,
+            pub d: wgpu::BindGroupEntry<'a>,
+            pub f: wgpu::BindGroupEntry<'a>,
+            pub h: wgpu::BindGroupEntry<'a>,
+            pub i: wgpu::BindGroupEntry<'a>,
+        }
+        impl<'a> WgpuBindGroup2EntryCollection<'a> {
+            pub fn new(params: WgpuBindGroup2EntryCollectionParams<'a>) -> Self {
+                Self {
+                    rts: wgpu::BindGroupEntry {
                         binding: 1,
-                        resource: wgpu::BindingResource::Buffer(self.rts),
+                        resource: wgpu::BindingResource::Buffer(params.rts),
                     },
-                    wgpu::BindGroupEntry {
+                    a: wgpu::BindGroupEntry {
                         binding: 2,
-                        resource: wgpu::BindingResource::Buffer(self.a),
+                        resource: wgpu::BindingResource::Buffer(params.a),
                     },
-                    wgpu::BindGroupEntry {
+                    b: wgpu::BindGroupEntry {
                         binding: 3,
-                        resource: wgpu::BindingResource::Buffer(self.b),
+                        resource: wgpu::BindingResource::Buffer(params.b),
                     },
-                    wgpu::BindGroupEntry {
+                    c: wgpu::BindGroupEntry {
                         binding: 4,
-                        resource: wgpu::BindingResource::Buffer(self.c),
+                        resource: wgpu::BindingResource::Buffer(params.c),
                     },
-                    wgpu::BindGroupEntry {
+                    d: wgpu::BindGroupEntry {
                         binding: 5,
-                        resource: wgpu::BindingResource::Buffer(self.d),
+                        resource: wgpu::BindingResource::Buffer(params.d),
                     },
-                    wgpu::BindGroupEntry {
+                    f: wgpu::BindGroupEntry {
                         binding: 6,
-                        resource: wgpu::BindingResource::Buffer(self.f),
+                        resource: wgpu::BindingResource::Buffer(params.f),
                     },
-                    wgpu::BindGroupEntry {
+                    h: wgpu::BindGroupEntry {
                         binding: 8,
-                        resource: wgpu::BindingResource::Buffer(self.h),
+                        resource: wgpu::BindingResource::Buffer(params.h),
                     },
-                    wgpu::BindGroupEntry {
+                    i: wgpu::BindGroupEntry {
                         binding: 9,
-                        resource: wgpu::BindingResource::Buffer(self.i),
+                        resource: wgpu::BindingResource::Buffer(params.i),
                     },
-                ]
+                }
+            }
+            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 8] {
+                [self.rts, self.a, self.b, self.c, self.d, self.f, self.h, self.i]
             }
         }
         #[derive(Debug)]
@@ -829,7 +860,7 @@ pub mod testbed {
             }
             pub fn from_bindings(
                 device: &wgpu::Device,
-                bindings: WgpuBindGroupLayout2,
+                bindings: WgpuBindGroup2EntryCollection,
             ) -> Self {
                 let bind_group_layout = Self::get_bind_group_layout(&device);
                 let entries = bindings.entries();
@@ -861,6 +892,7 @@ pub mod testbed {
             }
         }
     }
+    pub use self::bind_groups::*;
     pub fn set_bind_groups<'a>(
         pass: &mut wgpu::ComputePass<'a>,
         bind_group0: &'a bind_groups::WgpuBindGroup0,
@@ -1245,22 +1277,32 @@ pub mod triangle {
     pub mod bind_groups {
         use super::{_root, _root::*};
         #[derive(Debug)]
-        pub struct WgpuBindGroupLayout0<'a> {
+        pub struct WgpuBindGroup0EntryCollectionParams<'a> {
             pub color_texture: &'a wgpu::TextureView,
             pub color_sampler: &'a wgpu::Sampler,
         }
-        impl<'a> WgpuBindGroupLayout0<'a> {
-            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 2] {
-                [
-                    wgpu::BindGroupEntry {
+        #[derive(Debug)]
+        pub struct WgpuBindGroup0EntryCollection<'a> {
+            pub color_texture: wgpu::BindGroupEntry<'a>,
+            pub color_sampler: wgpu::BindGroupEntry<'a>,
+        }
+        impl<'a> WgpuBindGroup0EntryCollection<'a> {
+            pub fn new(params: WgpuBindGroup0EntryCollectionParams<'a>) -> Self {
+                Self {
+                    color_texture: wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::TextureView(self.color_texture),
+                        resource: wgpu::BindingResource::TextureView(
+                            params.color_texture,
+                        ),
                     },
-                    wgpu::BindGroupEntry {
+                    color_sampler: wgpu::BindGroupEntry {
                         binding: 1,
-                        resource: wgpu::BindingResource::Sampler(self.color_sampler),
+                        resource: wgpu::BindingResource::Sampler(params.color_sampler),
                     },
-                ]
+                }
+            }
+            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 2] {
+                [self.color_texture, self.color_sampler]
             }
         }
         #[derive(Debug)]
@@ -1300,7 +1342,7 @@ pub mod triangle {
             }
             pub fn from_bindings(
                 device: &wgpu::Device,
-                bindings: WgpuBindGroupLayout0,
+                bindings: WgpuBindGroup0EntryCollection,
             ) -> Self {
                 let bind_group_layout = Self::get_bind_group_layout(&device);
                 let entries = bindings.entries();
@@ -1319,17 +1361,24 @@ pub mod triangle {
             }
         }
         #[derive(Debug)]
-        pub struct WgpuBindGroupLayout1<'a> {
+        pub struct WgpuBindGroup1EntryCollectionParams<'a> {
             pub uniforms: wgpu::BufferBinding<'a>,
         }
-        impl<'a> WgpuBindGroupLayout1<'a> {
-            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 1] {
-                [
-                    wgpu::BindGroupEntry {
+        #[derive(Debug)]
+        pub struct WgpuBindGroup1EntryCollection<'a> {
+            pub uniforms: wgpu::BindGroupEntry<'a>,
+        }
+        impl<'a> WgpuBindGroup1EntryCollection<'a> {
+            pub fn new(params: WgpuBindGroup1EntryCollectionParams<'a>) -> Self {
+                Self {
+                    uniforms: wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::Buffer(self.uniforms),
+                        resource: wgpu::BindingResource::Buffer(params.uniforms),
                     },
-                ]
+                }
+            }
+            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 1] {
+                [self.uniforms]
             }
         }
         #[derive(Debug)]
@@ -1360,7 +1409,7 @@ pub mod triangle {
             }
             pub fn from_bindings(
                 device: &wgpu::Device,
-                bindings: WgpuBindGroupLayout1,
+                bindings: WgpuBindGroup1EntryCollection,
             ) -> Self {
                 let bind_group_layout = Self::get_bind_group_layout(&device);
                 let entries = bindings.entries();
@@ -1390,6 +1439,7 @@ pub mod triangle {
             }
         }
     }
+    pub use self::bind_groups::*;
     pub fn set_bind_groups<'a>(
         pass: &mut wgpu::RenderPass<'a>,
         bind_group0: &'a bind_groups::WgpuBindGroup0,

--- a/wgsl_bindgen/Cargo.toml
+++ b/wgsl_bindgen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wgsl_bindgen"
 authors.workspace = true
-version= "0.12.0"
+version.workspace = true
 edition.workspace = true
 repository.workspace = true
 documentation.workspace = true

--- a/wgsl_bindgen/src/bindgen/options/bindings.rs
+++ b/wgsl_bindgen/src/bindgen/options/bindings.rs
@@ -1,3 +1,6 @@
+use quote::format_ident;
+use syn::Ident;
+
 use crate::qs::{quote, Index, TokenStream};
 use crate::FastIndexMap;
 
@@ -30,10 +33,8 @@ impl std::fmt::Debug for BindingGenerator {
 /// and a map of binding resource types to their corresponding token streams.
 #[derive(Clone, Debug)]
 pub struct BindGroupLayoutGenerator {
-  /// The prefix name for the bind group layout.
-  ///
-  /// This is used as the prefix for the names of the generated bind group layout structures.
-  pub layout_prefix_name: String,
+  /// The prefix for the bind group layout.
+  pub name_prefix: String,
 
   /// Indicates whether the generated code uses lifetimes.
   ///
@@ -55,6 +56,19 @@ pub struct BindGroupLayoutGenerator {
   ///
   /// This map is used to generate the code for the binding resources in the bind group layout.
   pub binding_type_map: FastIndexMap<BindResourceType, TokenStream>,
+}
+
+impl BindGroupLayoutGenerator {
+  pub(crate) fn bind_group_name_ident(&self, group_index: u32) -> Ident {
+    format_ident!("{}{}", self.name_prefix, group_index)
+  }
+
+  pub(crate) fn bind_group_entry_collection_struct_name_ident(
+    &self,
+    group_index: u32,
+  ) -> Ident {
+    format_ident!("{}{}{}", self.name_prefix, group_index, "EntryCollection")
+  }
 }
 
 #[derive(Clone, Debug)]
@@ -116,7 +130,7 @@ impl WgpuGetBindingsGeneratorConfig {
     }
 
     BindGroupLayoutGenerator {
-      layout_prefix_name: "WgpuBindGroupLayout".into(),
+      name_prefix: "WgpuBindGroup".into(),
       uses_lifetime: true,
       entry_struct_type: quote!(wgpu::BindGroupEntry<'a>),
       entry_constructor,

--- a/wgsl_bindgen/src/generate/bind_group/layout_builder.rs
+++ b/wgsl_bindgen/src/generate/bind_group/layout_builder.rs
@@ -12,72 +12,116 @@ pub(super) struct BindGroupLayoutBuilder<'a> {
 }
 
 impl<'a> BindGroupLayoutBuilder<'a> {
-  fn entries(&self, binding_var_name: Ident) -> Vec<TokenStream> {
+  /// Generates a binding entry from a parameter variable and a group binding.
+  fn create_entry_from_parameter(
+    &self,
+    binding_var_name: &Ident,
+    binding: &GroupBinding,
+  ) -> TokenStream {
     let entry_cons = self.generator.entry_constructor;
+    let binding_index = binding.binding_index as usize;
+    let demangled_name = RustItemPath::from_mangled(
+      binding.name.as_ref().unwrap(),
+      self.invoking_entry_module,
+    );
+    let binding_name = Ident::new(&demangled_name.item_name, Span::call_site());
+    let binding_var = quote!(#binding_var_name.#binding_name);
 
+    match binding.binding_type.inner {
+      naga::TypeInner::Scalar(_)
+      | naga::TypeInner::Struct { .. }
+      | naga::TypeInner::Array { .. } => {
+        entry_cons(binding_index, binding_var, BindResourceType::Buffer)
+      }
+      naga::TypeInner::Image { .. } => {
+        entry_cons(binding_index, binding_var, BindResourceType::Texture)
+      }
+      naga::TypeInner::Sampler { .. } => {
+        entry_cons(binding_index, binding_var, BindResourceType::Sampler)
+      }
+      // TODO: Better error handling.
+      _ => panic!("Failed to generate BindingType."),
+    }
+  }
+
+  /// Assigns entries for the bind group from the provided parameters.
+  fn assign_entries_from_parameters(&self, param_var_name: Ident) -> Vec<TokenStream> {
     self
       .data
       .bindings
       .iter()
       .map(|binding| {
-        let binding_index = binding.binding_index as usize;
         let demangled_name = RustItemPath::from_mangled(
           binding.name.as_ref().unwrap(),
           self.invoking_entry_module,
         );
         let binding_name = Ident::new(&demangled_name.item_name, Span::call_site());
-        let binding_var = quote!(#binding_var_name.#binding_name);
+        let create_entry = self.create_entry_from_parameter(&param_var_name, binding);
 
-        match binding.binding_type.inner {
-          naga::TypeInner::Scalar(_)
-          | naga::TypeInner::Struct { .. }
-          | naga::TypeInner::Array { .. } => {
-            entry_cons(binding_index, binding_var, BindResourceType::Buffer)
-          }
-          naga::TypeInner::Image { .. } => {
-            entry_cons(binding_index, binding_var, BindResourceType::Texture)
-          }
-          naga::TypeInner::Sampler { .. } => {
-            entry_cons(binding_index, binding_var, BindResourceType::Sampler)
-          }
-          // TODO: Better error handling.
-          _ => panic!("Failed to generate BindingType."),
+        quote! {
+          #binding_name: #create_entry
         }
       })
       .collect()
   }
 
-  pub(super) fn build(&self) -> TokenStream {
-    let fields: Vec<_> = self
+  /// Generates a tuple of parameter field and entry field for a binding.
+  fn binding_field_tuple(&self, binding: &GroupBinding) -> (TokenStream, TokenStream) {
+    let rust_item_path = RustItemPath::from_mangled(
+      binding.name.as_ref().unwrap(),
+      self.invoking_entry_module,
+    );
+    let field_name = format_ident!("{}", &rust_item_path.item_name.as_str());
+
+    // TODO: Support more types.
+    let resource_type = match binding.binding_type.inner {
+      naga::TypeInner::Struct { .. } => BindResourceType::Buffer,
+      naga::TypeInner::Image { .. } => BindResourceType::Texture,
+      naga::TypeInner::Sampler { .. } => BindResourceType::Sampler,
+      naga::TypeInner::Array { .. } => BindResourceType::Buffer,
+      naga::TypeInner::Scalar(_) => BindResourceType::Buffer,
+      _ => panic!("Unsupported type for binding fields."),
+    };
+
+    let param_field_type = self.generator.binding_type_map[&resource_type].clone();
+    let field_type = self.generator.entry_struct_type.clone();
+
+    let param_field = quote!(pub #field_name: #param_field_type);
+    let entry_field = quote!(pub #field_name: #field_type);
+
+    (param_field, entry_field)
+  }
+
+  fn all_entries(&self, binding_var_name: Ident) -> Vec<TokenStream> {
+    self
       .data
       .bindings
       .iter()
       .map(|binding| {
-        let rust_item_path = RustItemPath::from_mangled(
+        let demangled_name = RustItemPath::from_mangled(
           binding.name.as_ref().unwrap(),
           self.invoking_entry_module,
         );
-        let field_name = format_ident!("{}", &rust_item_path.item_name.as_str());
-
-        // TODO: Support more types.
-        let resource_type = match binding.binding_type.inner {
-          naga::TypeInner::Struct { .. } => BindResourceType::Buffer,
-          naga::TypeInner::Image { .. } => BindResourceType::Texture,
-          naga::TypeInner::Sampler { .. } => BindResourceType::Sampler,
-          naga::TypeInner::Array { .. } => BindResourceType::Buffer,
-          naga::TypeInner::Scalar(_) => BindResourceType::Buffer,
-          _ => panic!("Unsupported type for binding fields."),
-        };
-
-        let field_type = self.generator.binding_type_map[&resource_type].clone();
-
-        quote!(pub #field_name: #field_type)
+        let binding_name = Ident::new(&demangled_name.item_name, Span::call_site());
+        quote! (#binding_var_name.#binding_name)
       })
+      .collect()
+  }
+
+  pub(super) fn build(&self) -> TokenStream {
+    let (entries_param_fields, entries_fields): (Vec<_>, Vec<_>) = self
+      .data
+      .bindings
+      .iter()
+      .map(|binding| self.binding_field_tuple(binding))
       .collect();
 
-    let name = indexed_name_ident(&self.generator.layout_prefix_name, self.group_no);
-    let entries = self.entries(format_ident!("self"));
-    let entries_length = Index::from(entries.len() as usize);
+    let entry_collection_name =
+      self.generator.bind_group_entry_collection_struct_name_ident(self.group_no);
+    let entry_collection_param_name = format_ident!(
+      "{}Params",
+      self.generator.bind_group_entry_collection_struct_name_ident(self.group_no)
+    );
     let entry_struct_type = self.generator.entry_struct_type.clone();
 
     let lifetime = if self.generator.uses_lifetime {
@@ -86,16 +130,31 @@ impl<'a> BindGroupLayoutBuilder<'a> {
       quote!()
     };
 
+    let entries_from_params =
+      self.assign_entries_from_parameters(format_ident!("params"));
+    let entries_length = Index::from(entries_from_params.len() as usize);
+    let all_entries = self.all_entries(format_ident!("self"));
+
     quote! {
         #[derive(Debug)]
-        pub struct #name #lifetime {
-            #(#fields),*
+        pub struct #entry_collection_param_name #lifetime {
+            #(#entries_param_fields),*
         }
 
-        impl #lifetime #name #lifetime {
+        #[derive(Debug)]
+        pub struct #entry_collection_name #lifetime {
+            #(#entries_fields),*
+        }
+
+        impl #lifetime #entry_collection_name #lifetime {
+          pub fn new(params: #entry_collection_param_name #lifetime) -> Self {
+            Self {
+              #(#entries_from_params),*
+            }
+          }
 
           pub fn entries(self) -> [#entry_struct_type; #entries_length] {
-            [ #(#entries),* ]
+            [ #(#all_entries),* ]
           }
         }
     }

--- a/wgsl_bindgen/src/generate/pipeline.rs
+++ b/wgsl_bindgen/src/generate/pipeline.rs
@@ -46,7 +46,10 @@ pub fn create_pipeline_layout_fn(
   let bind_group_layouts: Vec<_> = bind_group_data
     .keys()
     .map(|group_no| {
-      let group = indexed_name_ident("WgpuBindGroup", *group_no);
+      let group = options
+        .wgpu_binding_generator
+        .bind_group_layout
+        .bind_group_name_ident(*group_no);
       quote!(bind_groups::#group::get_bind_group_layout(device))
     })
     .collect();

--- a/wgsl_bindgen/tests/output/bindgen_bevy.expected.rs
+++ b/wgsl_bindgen/tests/output/bindgen_bevy.expected.rs
@@ -701,7 +701,7 @@ pub mod pbr {
     pub mod bind_groups {
         use super::{_root, _root::*};
         #[derive(Debug)]
-        pub struct WgpuBindGroupLayout0<'a> {
+        pub struct WgpuBindGroup0EntryCollectionParams<'a> {
             pub view: wgpu::BufferBinding<'a>,
             pub lights: wgpu::BufferBinding<'a>,
             pub point_lights: wgpu::BufferBinding<'a>,
@@ -712,57 +712,82 @@ pub mod pbr {
             pub directional_shadow_textures: &'a wgpu::TextureView,
             pub directional_shadow_textures_sampler: &'a wgpu::Sampler,
         }
-        impl<'a> WgpuBindGroupLayout0<'a> {
-            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 9] {
-                [
-                    wgpu::BindGroupEntry {
+        #[derive(Debug)]
+        pub struct WgpuBindGroup0EntryCollection<'a> {
+            pub view: wgpu::BindGroupEntry<'a>,
+            pub lights: wgpu::BindGroupEntry<'a>,
+            pub point_lights: wgpu::BindGroupEntry<'a>,
+            pub cluster_light_index_lists: wgpu::BindGroupEntry<'a>,
+            pub cluster_offsets_and_counts: wgpu::BindGroupEntry<'a>,
+            pub point_shadow_textures: wgpu::BindGroupEntry<'a>,
+            pub point_shadow_textures_sampler: wgpu::BindGroupEntry<'a>,
+            pub directional_shadow_textures: wgpu::BindGroupEntry<'a>,
+            pub directional_shadow_textures_sampler: wgpu::BindGroupEntry<'a>,
+        }
+        impl<'a> WgpuBindGroup0EntryCollection<'a> {
+            pub fn new(params: WgpuBindGroup0EntryCollectionParams<'a>) -> Self {
+                Self {
+                    view: wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::Buffer(self.view),
+                        resource: wgpu::BindingResource::Buffer(params.view),
                     },
-                    wgpu::BindGroupEntry {
+                    lights: wgpu::BindGroupEntry {
                         binding: 1,
-                        resource: wgpu::BindingResource::Buffer(self.lights),
+                        resource: wgpu::BindingResource::Buffer(params.lights),
                     },
-                    wgpu::BindGroupEntry {
+                    point_lights: wgpu::BindGroupEntry {
                         binding: 6,
-                        resource: wgpu::BindingResource::Buffer(self.point_lights),
+                        resource: wgpu::BindingResource::Buffer(params.point_lights),
                     },
-                    wgpu::BindGroupEntry {
+                    cluster_light_index_lists: wgpu::BindGroupEntry {
                         binding: 7,
                         resource: wgpu::BindingResource::Buffer(
-                            self.cluster_light_index_lists,
+                            params.cluster_light_index_lists,
                         ),
                     },
-                    wgpu::BindGroupEntry {
+                    cluster_offsets_and_counts: wgpu::BindGroupEntry {
                         binding: 8,
                         resource: wgpu::BindingResource::Buffer(
-                            self.cluster_offsets_and_counts,
+                            params.cluster_offsets_and_counts,
                         ),
                     },
-                    wgpu::BindGroupEntry {
+                    point_shadow_textures: wgpu::BindGroupEntry {
                         binding: 2,
                         resource: wgpu::BindingResource::TextureView(
-                            self.point_shadow_textures,
+                            params.point_shadow_textures,
                         ),
                     },
-                    wgpu::BindGroupEntry {
+                    point_shadow_textures_sampler: wgpu::BindGroupEntry {
                         binding: 3,
                         resource: wgpu::BindingResource::Sampler(
-                            self.point_shadow_textures_sampler,
+                            params.point_shadow_textures_sampler,
                         ),
                     },
-                    wgpu::BindGroupEntry {
+                    directional_shadow_textures: wgpu::BindGroupEntry {
                         binding: 4,
                         resource: wgpu::BindingResource::TextureView(
-                            self.directional_shadow_textures,
+                            params.directional_shadow_textures,
                         ),
                     },
-                    wgpu::BindGroupEntry {
+                    directional_shadow_textures_sampler: wgpu::BindGroupEntry {
                         binding: 5,
                         resource: wgpu::BindingResource::Sampler(
-                            self.directional_shadow_textures_sampler,
+                            params.directional_shadow_textures_sampler,
                         ),
                     },
+                }
+            }
+            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 9] {
+                [
+                    self.view,
+                    self.lights,
+                    self.point_lights,
+                    self.cluster_light_index_lists,
+                    self.cluster_offsets_and_counts,
+                    self.point_shadow_textures,
+                    self.point_shadow_textures_sampler,
+                    self.directional_shadow_textures,
+                    self.directional_shadow_textures_sampler,
                 ]
             }
         }
@@ -890,7 +915,7 @@ pub mod pbr {
             }
             pub fn from_bindings(
                 device: &wgpu::Device,
-                bindings: WgpuBindGroupLayout0,
+                bindings: WgpuBindGroup0EntryCollection,
             ) -> Self {
                 let bind_group_layout = Self::get_bind_group_layout(&device);
                 let entries = bindings.entries();
@@ -909,17 +934,24 @@ pub mod pbr {
             }
         }
         #[derive(Debug)]
-        pub struct WgpuBindGroupLayout1<'a> {
+        pub struct WgpuBindGroup1EntryCollectionParams<'a> {
             pub material: wgpu::BufferBinding<'a>,
         }
-        impl<'a> WgpuBindGroupLayout1<'a> {
-            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 1] {
-                [
-                    wgpu::BindGroupEntry {
+        #[derive(Debug)]
+        pub struct WgpuBindGroup1EntryCollection<'a> {
+            pub material: wgpu::BindGroupEntry<'a>,
+        }
+        impl<'a> WgpuBindGroup1EntryCollection<'a> {
+            pub fn new(params: WgpuBindGroup1EntryCollectionParams<'a>) -> Self {
+                Self {
+                    material: wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::Buffer(self.material),
+                        resource: wgpu::BindingResource::Buffer(params.material),
                     },
-                ]
+                }
+            }
+            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 1] {
+                [self.material]
             }
         }
         #[derive(Debug)]
@@ -952,7 +984,7 @@ pub mod pbr {
             }
             pub fn from_bindings(
                 device: &wgpu::Device,
-                bindings: WgpuBindGroupLayout1,
+                bindings: WgpuBindGroup1EntryCollection,
             ) -> Self {
                 let bind_group_layout = Self::get_bind_group_layout(&device);
                 let entries = bindings.entries();
@@ -971,17 +1003,24 @@ pub mod pbr {
             }
         }
         #[derive(Debug)]
-        pub struct WgpuBindGroupLayout2<'a> {
+        pub struct WgpuBindGroup2EntryCollectionParams<'a> {
             pub mesh: wgpu::BufferBinding<'a>,
         }
-        impl<'a> WgpuBindGroupLayout2<'a> {
-            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 1] {
-                [
-                    wgpu::BindGroupEntry {
+        #[derive(Debug)]
+        pub struct WgpuBindGroup2EntryCollection<'a> {
+            pub mesh: wgpu::BindGroupEntry<'a>,
+        }
+        impl<'a> WgpuBindGroup2EntryCollection<'a> {
+            pub fn new(params: WgpuBindGroup2EntryCollectionParams<'a>) -> Self {
+                Self {
+                    mesh: wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::Buffer(self.mesh),
+                        resource: wgpu::BindingResource::Buffer(params.mesh),
                     },
-                ]
+                }
+            }
+            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 1] {
+                [self.mesh]
             }
         }
         #[derive(Debug)]
@@ -1013,7 +1052,7 @@ pub mod pbr {
             }
             pub fn from_bindings(
                 device: &wgpu::Device,
-                bindings: WgpuBindGroupLayout2,
+                bindings: WgpuBindGroup2EntryCollection,
             ) -> Self {
                 let bind_group_layout = Self::get_bind_group_layout(&device);
                 let entries = bindings.entries();
@@ -1045,6 +1084,7 @@ pub mod pbr {
             }
         }
     }
+    pub use self::bind_groups::*;
     pub fn set_bind_groups<'a>(
         pass: &mut wgpu::RenderPass<'a>,
         bind_group0: &'a bind_groups::WgpuBindGroup0,

--- a/wgsl_bindgen/tests/output/bindgen_main.expected.rs
+++ b/wgsl_bindgen/tests/output/bindgen_main.expected.rs
@@ -101,32 +101,44 @@ pub mod main {
     pub mod bind_groups {
         use super::{_root, _root::*};
         #[derive(Debug)]
-        pub struct WgpuBindGroupLayout0<'a> {
+        pub struct WgpuBindGroup0EntryCollectionParams<'a> {
             pub buffer: wgpu::BufferBinding<'a>,
             pub texture_float: &'a wgpu::TextureView,
             pub texture_sint: &'a wgpu::TextureView,
             pub texture_uint: &'a wgpu::TextureView,
         }
-        impl<'a> WgpuBindGroupLayout0<'a> {
-            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 4] {
-                [
-                    wgpu::BindGroupEntry {
+        #[derive(Debug)]
+        pub struct WgpuBindGroup0EntryCollection<'a> {
+            pub buffer: wgpu::BindGroupEntry<'a>,
+            pub texture_float: wgpu::BindGroupEntry<'a>,
+            pub texture_sint: wgpu::BindGroupEntry<'a>,
+            pub texture_uint: wgpu::BindGroupEntry<'a>,
+        }
+        impl<'a> WgpuBindGroup0EntryCollection<'a> {
+            pub fn new(params: WgpuBindGroup0EntryCollectionParams<'a>) -> Self {
+                Self {
+                    buffer: wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::Buffer(self.buffer),
+                        resource: wgpu::BindingResource::Buffer(params.buffer),
                     },
-                    wgpu::BindGroupEntry {
+                    texture_float: wgpu::BindGroupEntry {
                         binding: 1,
-                        resource: wgpu::BindingResource::TextureView(self.texture_float),
+                        resource: wgpu::BindingResource::TextureView(
+                            params.texture_float,
+                        ),
                     },
-                    wgpu::BindGroupEntry {
+                    texture_sint: wgpu::BindGroupEntry {
                         binding: 2,
-                        resource: wgpu::BindingResource::TextureView(self.texture_sint),
+                        resource: wgpu::BindingResource::TextureView(params.texture_sint),
                     },
-                    wgpu::BindGroupEntry {
+                    texture_uint: wgpu::BindGroupEntry {
                         binding: 3,
-                        resource: wgpu::BindingResource::TextureView(self.texture_uint),
+                        resource: wgpu::BindingResource::TextureView(params.texture_uint),
                     },
-                ]
+                }
+            }
+            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 4] {
+                [self.buffer, self.texture_float, self.texture_sint, self.texture_uint]
             }
         }
         #[derive(Debug)]
@@ -192,7 +204,7 @@ pub mod main {
             }
             pub fn from_bindings(
                 device: &wgpu::Device,
-                bindings: WgpuBindGroupLayout0,
+                bindings: WgpuBindGroup0EntryCollection,
             ) -> Self {
                 let bind_group_layout = Self::get_bind_group_layout(&device);
                 let entries = bindings.entries();
@@ -211,17 +223,24 @@ pub mod main {
             }
         }
         #[derive(Debug)]
-        pub struct WgpuBindGroupLayout1<'a> {
+        pub struct WgpuBindGroup1EntryCollectionParams<'a> {
             pub ONE: wgpu::BufferBinding<'a>,
         }
-        impl<'a> WgpuBindGroupLayout1<'a> {
-            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 1] {
-                [
-                    wgpu::BindGroupEntry {
+        #[derive(Debug)]
+        pub struct WgpuBindGroup1EntryCollection<'a> {
+            pub ONE: wgpu::BindGroupEntry<'a>,
+        }
+        impl<'a> WgpuBindGroup1EntryCollection<'a> {
+            pub fn new(params: WgpuBindGroup1EntryCollectionParams<'a>) -> Self {
+                Self {
+                    ONE: wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::Buffer(self.ONE),
+                        resource: wgpu::BindingResource::Buffer(params.ONE),
                     },
-                ]
+                }
+            }
+            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 1] {
+                [self.ONE]
             }
         }
         #[derive(Debug)]
@@ -252,7 +271,7 @@ pub mod main {
             }
             pub fn from_bindings(
                 device: &wgpu::Device,
-                bindings: WgpuBindGroupLayout1,
+                bindings: WgpuBindGroup1EntryCollection,
             ) -> Self {
                 let bind_group_layout = Self::get_bind_group_layout(&device);
                 let entries = bindings.entries();
@@ -282,6 +301,7 @@ pub mod main {
             }
         }
     }
+    pub use self::bind_groups::*;
     pub fn set_bind_groups<'a>(
         pass: &mut wgpu::ComputePass<'a>,
         bind_group0: &'a bind_groups::WgpuBindGroup0,

--- a/wgsl_bindgen/tests/output/bindgen_minimal.expected.rs
+++ b/wgsl_bindgen/tests/output/bindgen_minimal.expected.rs
@@ -82,17 +82,24 @@ pub mod minimal {
     pub mod bind_groups {
         use super::{_root, _root::*};
         #[derive(Debug)]
-        pub struct WgpuBindGroupLayout0<'a> {
+        pub struct WgpuBindGroup0EntryCollectionParams<'a> {
             pub uniform_buf: wgpu::BufferBinding<'a>,
         }
-        impl<'a> WgpuBindGroupLayout0<'a> {
-            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 1] {
-                [
-                    wgpu::BindGroupEntry {
+        #[derive(Debug)]
+        pub struct WgpuBindGroup0EntryCollection<'a> {
+            pub uniform_buf: wgpu::BindGroupEntry<'a>,
+        }
+        impl<'a> WgpuBindGroup0EntryCollection<'a> {
+            pub fn new(params: WgpuBindGroup0EntryCollectionParams<'a>) -> Self {
+                Self {
+                    uniform_buf: wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::Buffer(self.uniform_buf),
+                        resource: wgpu::BindingResource::Buffer(params.uniform_buf),
                     },
-                ]
+                }
+            }
+            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 1] {
+                [self.uniform_buf]
             }
         }
         #[derive(Debug)]
@@ -123,7 +130,7 @@ pub mod minimal {
             }
             pub fn from_bindings(
                 device: &wgpu::Device,
-                bindings: WgpuBindGroupLayout0,
+                bindings: WgpuBindGroup0EntryCollection,
             ) -> Self {
                 let bind_group_layout = Self::get_bind_group_layout(&device);
                 let entries = bindings.entries();
@@ -151,6 +158,7 @@ pub mod minimal {
             }
         }
     }
+    pub use self::bind_groups::*;
     pub fn set_bind_groups<'a>(
         pass: &mut wgpu::ComputePass<'a>,
         bind_group0: &'a bind_groups::WgpuBindGroup0,

--- a/wgsl_bindgen/tests/output/bindgen_padding.expected.rs
+++ b/wgsl_bindgen/tests/output/bindgen_padding.expected.rs
@@ -85,17 +85,24 @@ pub mod padding {
     pub mod bind_groups {
         use super::{_root, _root::*};
         #[derive(Debug)]
-        pub struct WgpuBindGroupLayout0<'a> {
+        pub struct WgpuBindGroup0EntryCollectionParams<'a> {
             pub frame: wgpu::BufferBinding<'a>,
         }
-        impl<'a> WgpuBindGroupLayout0<'a> {
-            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 1] {
-                [
-                    wgpu::BindGroupEntry {
+        #[derive(Debug)]
+        pub struct WgpuBindGroup0EntryCollection<'a> {
+            pub frame: wgpu::BindGroupEntry<'a>,
+        }
+        impl<'a> WgpuBindGroup0EntryCollection<'a> {
+            pub fn new(params: WgpuBindGroup0EntryCollectionParams<'a>) -> Self {
+                Self {
+                    frame: wgpu::BindGroupEntry {
                         binding: 0,
-                        resource: wgpu::BindingResource::Buffer(self.frame),
+                        resource: wgpu::BindingResource::Buffer(params.frame),
                     },
-                ]
+                }
+            }
+            pub fn entries(self) -> [wgpu::BindGroupEntry<'a>; 1] {
+                [self.frame]
             }
         }
         #[derive(Debug)]
@@ -128,7 +135,7 @@ pub mod padding {
             }
             pub fn from_bindings(
                 device: &wgpu::Device,
-                bindings: WgpuBindGroupLayout0,
+                bindings: WgpuBindGroup0EntryCollection,
             ) -> Self {
                 let bind_group_layout = Self::get_bind_group_layout(&device);
                 let entries = bindings.entries();
@@ -156,6 +163,7 @@ pub mod padding {
             }
         }
     }
+    pub use self::bind_groups::*;
     pub fn set_bind_groups<'a>(
         pass: &mut wgpu::ComputePass<'a>,
         bind_group0: &'a bind_groups::WgpuBindGroup0,


### PR DESCRIPTION
## Bindgroups
* Renamed generated code like `WgpuBindGroupLayout0` to `WgpuBindGroup0EntryCollection`.
* Also allow to create the Entry collection using a helper struct `WgpuBindGroup0EntryCollectionParams`
* Re-export bind_groups at the shader entry module root. In the future we might just directly generate it at this place, since there shouldn't be any naming conflicts. 