### PR TITLE
Entrypoints Module

### DIFF
--- a/example/src/demos/particle_compute_demo.rs
+++ b/example/src/demos/particle_compute_demo.rs
@@ -1,11 +1,11 @@
 use crate::demos::Demo;
+use crate::shader_bindings::compute_demo::particle_physics::{
+  self, Job, Params, WgpuBindGroup1Entries, WgpuBindGroup1EntriesParams,
+};
 use crate::shader_bindings::global_bindings::{
   WgpuBindGroup0Entries, WgpuBindGroup0EntriesParams,
 };
-use crate::shader_bindings::particle_physics::{
-  self, Job, Params, WgpuBindGroup1Entries, WgpuBindGroup1EntriesParams,
-};
-use crate::shader_bindings::{self, particle_renderer};
+use crate::shader_bindings::{self, compute_demo::particle_renderer};
 use glam::Vec3;
 use wgpu::util::DeviceExt;
 use winit::event::KeyEvent;
@@ -171,7 +171,7 @@ impl Demo for ParticleComputeDemo {
     let compute_shader_module = particle_physics::create_shader_module_relative_path(
       device,
       crate::SHADER_DIR,
-      shader_bindings::ShaderEntry::ParticlePhysics,
+      shader_bindings::ShaderEntry::ComputeDemoParticlePhysics,
       std::collections::HashMap::new(),
       |path| std::fs::read_to_string(path),
     )
@@ -191,7 +191,7 @@ impl Demo for ParticleComputeDemo {
     let render_shader = particle_renderer::create_shader_module_relative_path(
       device,
       crate::SHADER_DIR,
-      shader_bindings::ShaderEntry::ParticleRenderer,
+      shader_bindings::ShaderEntry::ComputeDemoParticleRenderer,
       std::collections::HashMap::new(),
       |path| std::fs::read_to_string(path),
     )
@@ -205,7 +205,7 @@ impl Demo for ParticleComputeDemo {
         layout: Some(&render_pipeline_layout),
         vertex: wgpu::VertexState {
           module: &render_shader,
-          entry_point: Some(shader_bindings::particle_renderer::ENTRY_VS_MAIN),
+          entry_point: Some(particle_renderer::ENTRY_VS_MAIN),
           compilation_options: wgpu::PipelineCompilationOptions::default(),
           buffers: &[
             // Quad vertices (per vertex) - matches @location(0) quad_pos
@@ -230,15 +230,13 @@ impl Demo for ParticleComputeDemo {
             },
           ],
         },
-        fragment: Some(shader_bindings::particle_renderer::fragment_state(
+        fragment: Some(particle_renderer::fragment_state(
           &render_shader,
-          &shader_bindings::particle_renderer::fs_main_entry([Some(
-            wgpu::ColorTargetState {
-              format: surface_format,
-              blend: Some(wgpu::BlendState::ALPHA_BLENDING),
-              write_mask: wgpu::ColorWrites::ALL,
-            },
-          )]),
+          &particle_renderer::fs_main_entry([Some(wgpu::ColorTargetState {
+            format: surface_format,
+            blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+            write_mask: wgpu::ColorWrites::ALL,
+          })]),
         )),
         primitive: wgpu::PrimitiveState {
           topology: wgpu::PrimitiveTopology::TriangleList,

--- a/wgsl_bindgen/src/generate/shader_registry.rs
+++ b/wgsl_bindgen/src/generate/shader_registry.rs
@@ -33,11 +33,16 @@ impl<'a, 'b> ShaderEntryBuilder<'a, 'b> {
 
   fn build_create_pipeline_layout_fn(&self) -> TokenStream {
     let match_arms = self.entries.iter().map(|entry| {
-      let mod_path = format_ident!("{}", entry.mod_name);
+      // Convert module path like "lines::segment" to a proper Rust path
+      let mod_path_parts: Vec<_> = entry
+        .mod_name
+        .split("::")
+        .map(|part| format_ident!("{}", part))
+        .collect();
       let enum_variant = format_ident!("{}", sanitize_and_pascal_case(&entry.mod_name));
 
       quote! {
-        Self::#enum_variant => #mod_path::create_pipeline_layout(device)
+        Self::#enum_variant => #(#mod_path_parts)::*::create_pipeline_layout(device)
       }
     });
 
@@ -59,13 +64,13 @@ impl<'a, 'b> ShaderEntryBuilder<'a, 'b> {
       WgslShaderSourceType::ComposerWithRelativePath => {
         // For ComposerWithRelativePath, we need to pass the entry_point enum to the module function
         let match_arms = self.entries.iter().map(|entry| {
-          let mod_path = format_ident!("{}", entry.mod_name);
+          let mod_path_parts: Vec<_> = entry.mod_name.split("::").map(|part| format_ident!("{}", part)).collect();
           let enum_variant =
             format_ident!("{}", sanitize_and_pascal_case(&entry.mod_name));
 
           quote! {
             Self::#enum_variant => {
-              #mod_path::#fn_name(device, base_dir, *self, shader_defs, load_file)
+              #(#mod_path_parts)::*::#fn_name(device, base_dir, *self, shader_defs, load_file)
             }
           }
         });
@@ -81,13 +86,17 @@ impl<'a, 'b> ShaderEntryBuilder<'a, 'b> {
       }
       _ => {
         let match_arms = self.entries.iter().map(|entry| {
-          let mod_path = format_ident!("{}", entry.mod_name);
+          let mod_path_parts: Vec<_> = entry
+            .mod_name
+            .split("::")
+            .map(|part| format_ident!("{}", part))
+            .collect();
           let enum_variant =
             format_ident!("{}", sanitize_and_pascal_case(&entry.mod_name));
 
           quote! {
             Self::#enum_variant => {
-              #mod_path::#fn_name(#params)
+              #(#mod_path_parts)::*::#fn_name(#params)
             }
           }
         });
@@ -119,13 +128,17 @@ impl<'a, 'b> ShaderEntryBuilder<'a, 'b> {
         let fn_name = format_ident!("{}", source_type.load_shader_module_fn_name());
 
         let match_arms = self.entries.iter().map(|entry| {
-          let mod_path = format_ident!("{}", entry.mod_name);
+          let mod_path_parts: Vec<_> = entry
+            .mod_name
+            .split("::")
+            .map(|part| format_ident!("{}", part))
+            .collect();
           let enum_variant =
             format_ident!("{}", sanitize_and_pascal_case(&entry.mod_name));
 
           quote! {
             Self::#enum_variant => {
-              #mod_path::#fn_name(composer, shader_defs)
+              #(#mod_path_parts)::*::#fn_name(composer, shader_defs)
             }
           }
         });
@@ -155,11 +168,15 @@ impl<'a, 'b> ShaderEntryBuilder<'a, 'b> {
     }
 
     let match_arms = self.entries.iter().map(|entry| {
-      let mod_path = format_ident!("{}", entry.mod_name);
+      let mod_path_parts: Vec<_> = entry
+        .mod_name
+        .split("::")
+        .map(|part| format_ident!("{}", part))
+        .collect();
       let enum_variant = format_ident!("{}", sanitize_and_pascal_case(&entry.mod_name));
 
       quote! {
-        Self::#enum_variant => #mod_path::SHADER_ENTRY_PATH
+        Self::#enum_variant => #(#mod_path_parts)::*::SHADER_ENTRY_PATH
       }
     });
 

--- a/wgsl_bindgen/src/lib.rs
+++ b/wgsl_bindgen/src/lib.rs
@@ -357,7 +357,11 @@ fn indexed_name_ident(name: &str, index: u32) -> Ident {
 }
 
 fn sanitize_and_pascal_case(v: &str) -> String {
-  v.chars()
+  // Handle module paths by replacing "::" with "_" to preserve module boundaries
+  let normalized = v.replace("::", "_");
+
+  normalized
+    .chars()
     .filter(|ch| ch.is_alphanumeric() || *ch == '_')
     .collect::<String>()
     .to_pascal_case()
@@ -423,6 +427,31 @@ mod test {
 
   use self::bevy_util::source_file::SourceFile;
   use super::*;
+
+  #[test]
+  fn test_sanitize_and_pascal_case() {
+    // Test basic case
+    assert_eq!(sanitize_and_pascal_case("segment"), "Segment");
+
+    // Test module path handling
+    assert_eq!(sanitize_and_pascal_case("lines::segment"), "LinesSegment");
+
+    // Test complex nested paths
+    assert_eq!(
+      sanitize_and_pascal_case("compute_demo::particle_physics"),
+      "ComputeDemoParticlePhysics"
+    );
+
+    // Test multiple underscores and double colons
+    assert_eq!(
+      sanitize_and_pascal_case("bevy_pbr::mesh_view_bindings"),
+      "BevyPbrMeshViewBindings"
+    );
+
+    // Test edge cases
+    assert_eq!(sanitize_and_pascal_case("a::b::c::d"), "ABCD");
+    assert_eq!(sanitize_and_pascal_case("simple_name"), "SimpleName");
+  }
 
   fn create_shader_module(
     source: &str,

--- a/wgsl_bindgen/src/quote_gen/rust_struct_builder.rs
+++ b/wgsl_bindgen/src/quote_gen/rust_struct_builder.rs
@@ -1,3 +1,5 @@
+// See also: https://webgpufundamentals.org/webgpu/lessons/resources/wgsl-offset-computer.html
+
 use derive_more::IsVariant;
 use naga::common::wgsl::TypeContext;
 use naga::StructMember;

--- a/wgsl_bindgen/tests/bindgen_tests.rs
+++ b/wgsl_bindgen/tests/bindgen_tests.rs
@@ -33,7 +33,7 @@ fn test_bevy_bindgen() -> Result<()> {
 fn test_main_bindgen() -> Result<()> {
   WgslBindgenOptionBuilder::default()
     .add_entry_point("tests/shaders/basic/main.wgsl")
-    .workspace_root("tests/shaders/additional")
+    .workspace_root("tests/shaders")
     .additional_scan_dir((None, "tests/shaders/additional"))
     .override_struct_alignment([("main::Style", 256)].map(Into::into))
     .serialization_strategy(WgslTypeSerializeStrategy::Bytemuck)

--- a/wgsl_bindgen/tests/shaders/lines/segment.wgsl
+++ b/wgsl_bindgen/tests/shaders/lines/segment.wgsl
@@ -1,0 +1,33 @@
+struct SegmentData {
+    start: vec2<f32>,
+    end: vec2<f32>,
+    color: vec4<f32>,
+}
+
+@group(0) @binding(0)
+var<uniform> segment: SegmentData;
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+    var output: VertexOutput;
+    
+    // Simple line segment using vertex_index 0 and 1
+    if (vertex_index == 0u) {
+        output.position = vec4<f32>(segment.start, 0.0, 1.0);
+    } else {
+        output.position = vec4<f32>(segment.end, 0.0, 1.0);
+    }
+    
+    output.color = segment.color;
+    return output;
+}
+
+@fragment
+fn fs_main(@location(0) color: vec4<f32>) -> @location(0) vec4<f32> {
+    return color;
+}

--- a/wgsl_bindgen/tests/snapshots/bevy_bindgen.snap
+++ b/wgsl_bindgen/tests/snapshots/bevy_bindgen.snap
@@ -360,7 +360,7 @@ pub mod bevy_pbr {
       impl WgpuBindGroup1 {
         pub const LAYOUT_DESCRIPTOR: wgpu::BindGroupLayoutDescriptor<'static> =
           wgpu::BindGroupLayoutDescriptor {
-            label: Some("BevyPbrpbrbindings::BindGroup1::LayoutDescriptor"),
+            label: Some("BevyPbrPbrBindings::BindGroup1::LayoutDescriptor"),
             entries: &[
               #[doc = " @binding(0): \"_root::bevy_pbr::pbr::bindings::material\""]
               wgpu::BindGroupLayoutEntry {
@@ -387,7 +387,7 @@ pub mod bevy_pbr {
           let bind_group_layout = Self::get_bind_group_layout(device);
           let entries = bindings.into_array();
           let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-            label: Some("BevyPbrpbrbindings::BindGroup1"),
+            label: Some("BevyPbrPbrBindings::BindGroup1"),
             layout: &bind_group_layout,
             entries: &entries,
           });
@@ -837,7 +837,7 @@ pub mod bevy_pbr {
     impl WgpuBindGroup0 {
       pub const LAYOUT_DESCRIPTOR: wgpu::BindGroupLayoutDescriptor<'static> =
         wgpu::BindGroupLayoutDescriptor {
-          label: Some("BevyPbrmeshViewBindings::BindGroup0::LayoutDescriptor"),
+          label: Some("BevyPbrMeshViewBindings::BindGroup0::LayoutDescriptor"),
           entries: &[
             #[doc = " @binding(0): \"_root::bevy_pbr::mesh_view_bindings::view\""]
             wgpu::BindGroupLayoutEntry {
@@ -946,7 +946,7 @@ pub mod bevy_pbr {
         let bind_group_layout = Self::get_bind_group_layout(device);
         let entries = bindings.into_array();
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-          label: Some("BevyPbrmeshViewBindings::BindGroup0"),
+          label: Some("BevyPbrMeshViewBindings::BindGroup0"),
           layout: &bind_group_layout,
           entries: &entries,
         });
@@ -988,7 +988,7 @@ pub mod bevy_pbr {
     impl WgpuBindGroup2 {
       pub const LAYOUT_DESCRIPTOR: wgpu::BindGroupLayoutDescriptor<'static> =
         wgpu::BindGroupLayoutDescriptor {
-          label: Some("BevyPbrmeshBindings::BindGroup2::LayoutDescriptor"),
+          label: Some("BevyPbrMeshBindings::BindGroup2::LayoutDescriptor"),
           entries: &[
             #[doc = " @binding(0): \"_root::bevy_pbr::mesh_bindings::mesh\""]
             wgpu::BindGroupLayoutEntry {
@@ -1015,7 +1015,7 @@ pub mod bevy_pbr {
         let bind_group_layout = Self::get_bind_group_layout(device);
         let entries = bindings.into_array();
         let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-          label: Some("BevyPbrmeshBindings::BindGroup2"),
+          label: Some("BevyPbrMeshBindings::BindGroup2"),
           layout: &bind_group_layout,
           entries: &entries,
         });

--- a/wgsl_bindgen/tests/snapshots/main_bindgen.snap
+++ b/wgsl_bindgen/tests/snapshots/main_bindgen.snap
@@ -4,12 +4,12 @@ source: wgsl_bindgen/tests/bindgen_tests.rs
 #![allow(unused, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ShaderEntry {
-  Main,
+  BasicMain,
 }
 impl ShaderEntry {
   pub fn create_pipeline_layout(&self, device: &wgpu::Device) -> wgpu::PipelineLayout {
     match self {
-      Self::Main => main::create_pipeline_layout(device),
+      Self::BasicMain => basic::main::create_pipeline_layout(device),
     }
   }
   pub fn create_shader_module_embed_source(
@@ -17,7 +17,7 @@ impl ShaderEntry {
     device: &wgpu::Device,
   ) -> wgpu::ShaderModule {
     match self {
-      Self::Main => main::create_shader_module_embed_source(device),
+      Self::BasicMain => basic::main::create_shader_module_embed_source(device),
     }
   }
   pub fn create_shader_module_relative_path(
@@ -29,7 +29,7 @@ impl ShaderEntry {
     load_file: impl Fn(&str) -> Result<String, std::io::Error>,
   ) -> Result<wgpu::ShaderModule, naga_oil::compose::ComposerError> {
     match self {
-      Self::Main => main::create_shader_module_relative_path(
+      Self::BasicMain => basic::main::create_shader_module_relative_path(
         device,
         base_dir,
         *self,
@@ -40,7 +40,7 @@ impl ShaderEntry {
   }
   pub fn relative_path(&self) -> &'static str {
     match self {
-      Self::Main => main::SHADER_ENTRY_PATH,
+      Self::BasicMain => basic::main::SHADER_ENTRY_PATH,
     }
   }
 }
@@ -227,259 +227,266 @@ pub mod layout_asserts {
     assert!(std::mem::size_of::<glam::Mat4>() == 64);
     assert!(std::mem::align_of::<glam::Mat4>() == 16);
   };
-  const MAIN_STYLE_ASSERTS: () = {
-    assert!(std::mem::offset_of!(main::Style, color) == 0);
-    assert!(std::mem::offset_of!(main::Style, width) == 16);
-    assert!(std::mem::size_of::<main::Style>() == 256);
+  const BASICMAIN_STYLE_ASSERTS: () = {
+    assert!(std::mem::offset_of!(basic::main::Style, color) == 0);
+    assert!(std::mem::offset_of!(basic::main::Style, width) == 16);
+    assert!(std::mem::size_of::<basic::main::Style>() == 256);
   };
 }
-pub mod main {
+pub mod basic {
   use super::{_root, _root::*};
-  #[repr(C, align(256))]
-  #[derive(Debug, PartialEq, Clone, Copy)]
-  pub struct Style {
-    #[doc = " size: 16, offset: 0x0, type: `vec4<f32>`"]
-    pub color: glam::Vec4,
-    #[doc = " size: 4, offset: 0x10, type: `f32`"]
-    pub width: f32,
-    pub _pad_width: [u8; 0xC],
-  }
-  impl Style {
-    pub const fn new(color: glam::Vec4, width: f32) -> Self {
-      Self {
-        color,
-        width,
-        _pad_width: [0; 0xC],
-      }
-    }
-  }
-  #[repr(C)]
-  #[derive(Debug, PartialEq, Clone, Copy)]
-  pub struct StyleInit {
-    pub color: glam::Vec4,
-    pub width: f32,
-  }
-  impl StyleInit {
-    pub const fn build(&self) -> Style {
-      Style {
-        color: self.color,
-        width: self.width,
-        _pad_width: [0; 0xC],
-      }
-    }
-  }
-  impl From<StyleInit> for Style {
-    fn from(data: StyleInit) -> Self {
-      data.build()
-    }
-  }
-  pub mod compute {
+  pub mod main {
     use super::{_root, _root::*};
-    pub const MAIN_WORKGROUP_SIZE: [u32; 3] = [1, 1, 1];
-    pub fn create_main_pipeline_embed_source(
-      device: &wgpu::Device,
-    ) -> wgpu::ComputePipeline {
-      let module = super::create_shader_module_embed_source(device);
-      let layout = super::create_pipeline_layout(device);
-      device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-        label: Some("Compute Pipeline main"),
-        layout: Some(&layout),
-        module: &module,
-        entry_point: Some("main"),
-        compilation_options: Default::default(),
-        cache: None,
+    #[repr(C, align(256))]
+    #[derive(Debug, PartialEq, Clone, Copy)]
+    pub struct Style {
+      #[doc = " size: 16, offset: 0x0, type: `vec4<f32>`"]
+      pub color: glam::Vec4,
+      #[doc = " size: 4, offset: 0x10, type: `f32`"]
+      pub width: f32,
+      pub _pad_width: [u8; 0xC],
+    }
+    impl Style {
+      pub const fn new(color: glam::Vec4, width: f32) -> Self {
+        Self {
+          color,
+          width,
+          _pad_width: [0; 0xC],
+        }
+      }
+    }
+    #[repr(C)]
+    #[derive(Debug, PartialEq, Clone, Copy)]
+    pub struct StyleInit {
+      pub color: glam::Vec4,
+      pub width: f32,
+    }
+    impl StyleInit {
+      pub const fn build(&self) -> Style {
+        Style {
+          color: self.color,
+          width: self.width,
+          _pad_width: [0; 0xC],
+        }
+      }
+    }
+    impl From<StyleInit> for Style {
+      fn from(data: StyleInit) -> Self {
+        data.build()
+      }
+    }
+    pub mod compute {
+      use super::{_root, _root::*};
+      pub const MAIN_WORKGROUP_SIZE: [u32; 3] = [1, 1, 1];
+      pub fn create_main_pipeline_embed_source(
+        device: &wgpu::Device,
+      ) -> wgpu::ComputePipeline {
+        let module = super::create_shader_module_embed_source(device);
+        let layout = super::create_pipeline_layout(device);
+        device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+          label: Some("Compute Pipeline main"),
+          layout: Some(&layout),
+          module: &module,
+          entry_point: Some("main"),
+          compilation_options: Default::default(),
+          cache: None,
+        })
+      }
+      pub fn create_main_pipeline_relative_path(
+        device: &wgpu::Device,
+        base_dir: &str,
+        entry_point: ShaderEntry,
+        shader_defs: std::collections::HashMap<String, naga_oil::compose::ShaderDefValue>,
+        load_file: impl Fn(&str) -> Result<String, std::io::Error>,
+      ) -> Result<wgpu::ComputePipeline, naga_oil::compose::ComposerError> {
+        let module = super::create_shader_module_relative_path(
+          device,
+          base_dir,
+          entry_point,
+          shader_defs,
+          load_file,
+        )?;
+        let layout = super::create_pipeline_layout(device);
+        Ok(device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+          label: Some("Compute Pipeline main"),
+          layout: Some(&layout),
+          module: &module,
+          entry_point: Some("main"),
+          compilation_options: Default::default(),
+          cache: None,
+        }))
+      }
+    }
+    pub const ENTRY_MAIN: &str = "main";
+    #[derive(Debug)]
+    pub struct WgpuBindGroup0EntriesParams<'a> {
+      pub buffer: wgpu::BufferBinding<'a>,
+      pub texture_float: &'a wgpu::TextureView,
+      pub texture_sint: &'a wgpu::TextureView,
+      pub texture_uint: &'a wgpu::TextureView,
+    }
+    #[derive(Clone, Debug)]
+    pub struct WgpuBindGroup0Entries<'a> {
+      pub buffer: wgpu::BindGroupEntry<'a>,
+      pub texture_float: wgpu::BindGroupEntry<'a>,
+      pub texture_sint: wgpu::BindGroupEntry<'a>,
+      pub texture_uint: wgpu::BindGroupEntry<'a>,
+    }
+    impl<'a> WgpuBindGroup0Entries<'a> {
+      pub fn new(params: WgpuBindGroup0EntriesParams<'a>) -> Self {
+        Self {
+          buffer: wgpu::BindGroupEntry {
+            binding: 0,
+            resource: wgpu::BindingResource::Buffer(params.buffer),
+          },
+          texture_float: wgpu::BindGroupEntry {
+            binding: 1,
+            resource: wgpu::BindingResource::TextureView(params.texture_float),
+          },
+          texture_sint: wgpu::BindGroupEntry {
+            binding: 2,
+            resource: wgpu::BindingResource::TextureView(params.texture_sint),
+          },
+          texture_uint: wgpu::BindGroupEntry {
+            binding: 3,
+            resource: wgpu::BindingResource::TextureView(params.texture_uint),
+          },
+        }
+      }
+      pub fn into_array(self) -> [wgpu::BindGroupEntry<'a>; 4] {
+        [
+          self.buffer,
+          self.texture_float,
+          self.texture_sint,
+          self.texture_uint,
+        ]
+      }
+      pub fn collect<B: FromIterator<wgpu::BindGroupEntry<'a>>>(self) -> B {
+        self.into_array().into_iter().collect()
+      }
+    }
+    #[derive(Debug)]
+    pub struct WgpuBindGroup0(wgpu::BindGroup);
+    impl WgpuBindGroup0 {
+      pub const LAYOUT_DESCRIPTOR: wgpu::BindGroupLayoutDescriptor<'static> =
+        wgpu::BindGroupLayoutDescriptor {
+          label: Some("BasicMain::BindGroup0::LayoutDescriptor"),
+          entries: &[
+            #[doc = " @binding(0): \"buffer\""]
+            wgpu::BindGroupLayoutEntry {
+              binding: 0,
+              visibility: wgpu::ShaderStages::COMPUTE,
+              ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Storage { read_only: false },
+                has_dynamic_offset: false,
+                min_binding_size: None,
+              },
+              count: None,
+            },
+            #[doc = " @binding(1): \"texture_float\""]
+            wgpu::BindGroupLayoutEntry {
+              binding: 1,
+              visibility: wgpu::ShaderStages::COMPUTE,
+              ty: wgpu::BindingType::Texture {
+                sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                view_dimension: wgpu::TextureViewDimension::D2,
+                multisampled: false,
+              },
+              count: None,
+            },
+            #[doc = " @binding(2): \"texture_sint\""]
+            wgpu::BindGroupLayoutEntry {
+              binding: 2,
+              visibility: wgpu::ShaderStages::COMPUTE,
+              ty: wgpu::BindingType::Texture {
+                sample_type: wgpu::TextureSampleType::Sint,
+                view_dimension: wgpu::TextureViewDimension::D2,
+                multisampled: false,
+              },
+              count: None,
+            },
+            #[doc = " @binding(3): \"texture_uint\""]
+            wgpu::BindGroupLayoutEntry {
+              binding: 3,
+              visibility: wgpu::ShaderStages::COMPUTE,
+              ty: wgpu::BindingType::Texture {
+                sample_type: wgpu::TextureSampleType::Uint,
+                view_dimension: wgpu::TextureViewDimension::D2,
+                multisampled: false,
+              },
+              count: None,
+            },
+          ],
+        };
+      pub fn get_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
+        device.create_bind_group_layout(&Self::LAYOUT_DESCRIPTOR)
+      }
+      pub fn from_bindings(
+        device: &wgpu::Device,
+        bindings: WgpuBindGroup0Entries,
+      ) -> Self {
+        let bind_group_layout = Self::get_bind_group_layout(device);
+        let entries = bindings.into_array();
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+          label: Some("BasicMain::BindGroup0"),
+          layout: &bind_group_layout,
+          entries: &entries,
+        });
+        Self(bind_group)
+      }
+      pub fn set(&self, pass: &mut impl SetBindGroup) {
+        pass.set_bind_group(0, &self.0, &[]);
+      }
+    }
+    #[doc = " Bind groups can be set individually using their set(render_pass) method, or all at once using `WgpuBindGroups::set`."]
+    #[doc = " For optimal performance with many draw calls, it's recommended to organize bindings into bind groups based on update frequency:"]
+    #[doc = "   - Bind group 0: Least frequent updates (e.g. per frame resources)"]
+    #[doc = "   - Bind group 1: More frequent updates"]
+    #[doc = "   - Bind group 2: More frequent updates"]
+    #[doc = "   - Bind group 3: Most frequent updates (e.g. per draw resources)"]
+    #[derive(Debug, Copy, Clone)]
+    pub struct WgpuBindGroups<'a> {
+      pub bind_group0: &'a WgpuBindGroup0,
+      pub bind_group1: &'a bindings::WgpuBindGroup1,
+    }
+    impl<'a> WgpuBindGroups<'a> {
+      pub fn set(&self, pass: &mut impl SetBindGroup) {
+        self.bind_group0.set(pass);
+        self.bind_group1.set(pass);
+      }
+    }
+    #[derive(Debug)]
+    pub struct WgpuPipelineLayout;
+    impl WgpuPipelineLayout {
+      pub fn bind_group_layout_entries(
+        entries: [wgpu::BindGroupLayout; 2],
+      ) -> [wgpu::BindGroupLayout; 2] {
+        entries
+      }
+    }
+    pub fn create_pipeline_layout(device: &wgpu::Device) -> wgpu::PipelineLayout {
+      device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("BasicMain::PipelineLayout"),
+        bind_group_layouts: &[
+          &WgpuBindGroup0::get_bind_group_layout(device),
+          &bindings::WgpuBindGroup1::get_bind_group_layout(device),
+        ],
+        push_constant_ranges: &[wgpu::PushConstantRange {
+          stages: wgpu::ShaderStages::COMPUTE,
+          range: 0..32,
+        }],
       })
     }
-    pub fn create_main_pipeline_relative_path(
+    pub fn create_shader_module_embed_source(
       device: &wgpu::Device,
-      base_dir: &str,
-      entry_point: ShaderEntry,
-      shader_defs: std::collections::HashMap<String, naga_oil::compose::ShaderDefValue>,
-      load_file: impl Fn(&str) -> Result<String, std::io::Error>,
-    ) -> Result<wgpu::ComputePipeline, naga_oil::compose::ComposerError> {
-      let module = super::create_shader_module_relative_path(
-        device,
-        base_dir,
-        entry_point,
-        shader_defs,
-        load_file,
-      )?;
-      let layout = super::create_pipeline_layout(device);
-      Ok(device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-        label: Some("Compute Pipeline main"),
-        layout: Some(&layout),
-        module: &module,
-        entry_point: Some("main"),
-        compilation_options: Default::default(),
-        cache: None,
-      }))
+    ) -> wgpu::ShaderModule {
+      let source = std::borrow::Cow::Borrowed(SHADER_STRING);
+      device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("main.wgsl"),
+        source: wgpu::ShaderSource::Wgsl(source),
+      })
     }
-  }
-  pub const ENTRY_MAIN: &str = "main";
-  #[derive(Debug)]
-  pub struct WgpuBindGroup0EntriesParams<'a> {
-    pub buffer: wgpu::BufferBinding<'a>,
-    pub texture_float: &'a wgpu::TextureView,
-    pub texture_sint: &'a wgpu::TextureView,
-    pub texture_uint: &'a wgpu::TextureView,
-  }
-  #[derive(Clone, Debug)]
-  pub struct WgpuBindGroup0Entries<'a> {
-    pub buffer: wgpu::BindGroupEntry<'a>,
-    pub texture_float: wgpu::BindGroupEntry<'a>,
-    pub texture_sint: wgpu::BindGroupEntry<'a>,
-    pub texture_uint: wgpu::BindGroupEntry<'a>,
-  }
-  impl<'a> WgpuBindGroup0Entries<'a> {
-    pub fn new(params: WgpuBindGroup0EntriesParams<'a>) -> Self {
-      Self {
-        buffer: wgpu::BindGroupEntry {
-          binding: 0,
-          resource: wgpu::BindingResource::Buffer(params.buffer),
-        },
-        texture_float: wgpu::BindGroupEntry {
-          binding: 1,
-          resource: wgpu::BindingResource::TextureView(params.texture_float),
-        },
-        texture_sint: wgpu::BindGroupEntry {
-          binding: 2,
-          resource: wgpu::BindingResource::TextureView(params.texture_sint),
-        },
-        texture_uint: wgpu::BindGroupEntry {
-          binding: 3,
-          resource: wgpu::BindingResource::TextureView(params.texture_uint),
-        },
-      }
-    }
-    pub fn into_array(self) -> [wgpu::BindGroupEntry<'a>; 4] {
-      [
-        self.buffer,
-        self.texture_float,
-        self.texture_sint,
-        self.texture_uint,
-      ]
-    }
-    pub fn collect<B: FromIterator<wgpu::BindGroupEntry<'a>>>(self) -> B {
-      self.into_array().into_iter().collect()
-    }
-  }
-  #[derive(Debug)]
-  pub struct WgpuBindGroup0(wgpu::BindGroup);
-  impl WgpuBindGroup0 {
-    pub const LAYOUT_DESCRIPTOR: wgpu::BindGroupLayoutDescriptor<'static> =
-      wgpu::BindGroupLayoutDescriptor {
-        label: Some("Main::BindGroup0::LayoutDescriptor"),
-        entries: &[
-          #[doc = " @binding(0): \"buffer\""]
-          wgpu::BindGroupLayoutEntry {
-            binding: 0,
-            visibility: wgpu::ShaderStages::COMPUTE,
-            ty: wgpu::BindingType::Buffer {
-              ty: wgpu::BufferBindingType::Storage { read_only: false },
-              has_dynamic_offset: false,
-              min_binding_size: None,
-            },
-            count: None,
-          },
-          #[doc = " @binding(1): \"texture_float\""]
-          wgpu::BindGroupLayoutEntry {
-            binding: 1,
-            visibility: wgpu::ShaderStages::COMPUTE,
-            ty: wgpu::BindingType::Texture {
-              sample_type: wgpu::TextureSampleType::Float { filterable: true },
-              view_dimension: wgpu::TextureViewDimension::D2,
-              multisampled: false,
-            },
-            count: None,
-          },
-          #[doc = " @binding(2): \"texture_sint\""]
-          wgpu::BindGroupLayoutEntry {
-            binding: 2,
-            visibility: wgpu::ShaderStages::COMPUTE,
-            ty: wgpu::BindingType::Texture {
-              sample_type: wgpu::TextureSampleType::Sint,
-              view_dimension: wgpu::TextureViewDimension::D2,
-              multisampled: false,
-            },
-            count: None,
-          },
-          #[doc = " @binding(3): \"texture_uint\""]
-          wgpu::BindGroupLayoutEntry {
-            binding: 3,
-            visibility: wgpu::ShaderStages::COMPUTE,
-            ty: wgpu::BindingType::Texture {
-              sample_type: wgpu::TextureSampleType::Uint,
-              view_dimension: wgpu::TextureViewDimension::D2,
-              multisampled: false,
-            },
-            count: None,
-          },
-        ],
-      };
-    pub fn get_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-      device.create_bind_group_layout(&Self::LAYOUT_DESCRIPTOR)
-    }
-    pub fn from_bindings(device: &wgpu::Device, bindings: WgpuBindGroup0Entries) -> Self {
-      let bind_group_layout = Self::get_bind_group_layout(device);
-      let entries = bindings.into_array();
-      let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-        label: Some("Main::BindGroup0"),
-        layout: &bind_group_layout,
-        entries: &entries,
-      });
-      Self(bind_group)
-    }
-    pub fn set(&self, pass: &mut impl SetBindGroup) {
-      pass.set_bind_group(0, &self.0, &[]);
-    }
-  }
-  #[doc = " Bind groups can be set individually using their set(render_pass) method, or all at once using `WgpuBindGroups::set`."]
-  #[doc = " For optimal performance with many draw calls, it's recommended to organize bindings into bind groups based on update frequency:"]
-  #[doc = "   - Bind group 0: Least frequent updates (e.g. per frame resources)"]
-  #[doc = "   - Bind group 1: More frequent updates"]
-  #[doc = "   - Bind group 2: More frequent updates"]
-  #[doc = "   - Bind group 3: Most frequent updates (e.g. per draw resources)"]
-  #[derive(Debug, Copy, Clone)]
-  pub struct WgpuBindGroups<'a> {
-    pub bind_group0: &'a WgpuBindGroup0,
-    pub bind_group1: &'a bindings::WgpuBindGroup1,
-  }
-  impl<'a> WgpuBindGroups<'a> {
-    pub fn set(&self, pass: &mut impl SetBindGroup) {
-      self.bind_group0.set(pass);
-      self.bind_group1.set(pass);
-    }
-  }
-  #[derive(Debug)]
-  pub struct WgpuPipelineLayout;
-  impl WgpuPipelineLayout {
-    pub fn bind_group_layout_entries(
-      entries: [wgpu::BindGroupLayout; 2],
-    ) -> [wgpu::BindGroupLayout; 2] {
-      entries
-    }
-  }
-  pub fn create_pipeline_layout(device: &wgpu::Device) -> wgpu::PipelineLayout {
-    device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-      label: Some("Main::PipelineLayout"),
-      bind_group_layouts: &[
-        &WgpuBindGroup0::get_bind_group_layout(device),
-        &bindings::WgpuBindGroup1::get_bind_group_layout(device),
-      ],
-      push_constant_ranges: &[wgpu::PushConstantRange {
-        stages: wgpu::ShaderStages::COMPUTE,
-        range: 0..32,
-      }],
-    })
-  }
-  pub fn create_shader_module_embed_source(device: &wgpu::Device) -> wgpu::ShaderModule {
-    let source = std::borrow::Cow::Borrowed(SHADER_STRING);
-    device.create_shader_module(wgpu::ShaderModuleDescriptor {
-      label: Some("main.wgsl"),
-      source: wgpu::ShaderSource::Wgsl(source),
-    })
-  }
-  pub const SHADER_STRING: &str = r#"
+    pub const SHADER_STRING: &str = r#"
 struct Style {
     color: vec4<f32>,
     width: f32,
@@ -507,42 +514,43 @@ fn main(@builtin(global_invocation_id) id: vec3<u32>) {
     return;
 }
 "#;
-  pub const SHADER_ENTRY_PATH: &str = "../basic/main.wgsl";
-  pub fn create_shader_module_relative_path(
-    device: &wgpu::Device,
-    base_dir: &str,
-    entry_point: ShaderEntry,
-    shader_defs: std::collections::HashMap<String, naga_oil::compose::ShaderDefValue>,
-    load_file: impl Fn(&str) -> Result<String, std::io::Error>,
-  ) -> Result<wgpu::ShaderModule, naga_oil::compose::ComposerError> {
-    let mut composer = naga_oil::compose::Composer::default()
-      .with_capabilities(wgpu::naga::valid::Capabilities::PUSH_CONSTANT);
-    let module = load_naga_module_from_path(
-      base_dir,
-      entry_point,
-      &mut composer,
-      shader_defs,
-      load_file,
-    )
-    .map_err(|e| naga_oil::compose::ComposerError {
-      inner: naga_oil::compose::ComposerErrorInner::ImportNotFound(e, 0),
-      source: naga_oil::compose::ErrSource::Constructing {
-        path: "load_naga_module_from_path".to_string(),
-        source: "Generated code".to_string(),
-        offset: 0,
-      },
-    })?;
-    let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-      label: Some("main.wgsl"),
-      source: wgpu::ShaderSource::Naga(std::borrow::Cow::Owned(module)),
-    });
-    Ok(shader_module)
+    pub const SHADER_ENTRY_PATH: &str = "basic/main.wgsl";
+    pub fn create_shader_module_relative_path(
+      device: &wgpu::Device,
+      base_dir: &str,
+      entry_point: ShaderEntry,
+      shader_defs: std::collections::HashMap<String, naga_oil::compose::ShaderDefValue>,
+      load_file: impl Fn(&str) -> Result<String, std::io::Error>,
+    ) -> Result<wgpu::ShaderModule, naga_oil::compose::ComposerError> {
+      let mut composer = naga_oil::compose::Composer::default()
+        .with_capabilities(wgpu::naga::valid::Capabilities::PUSH_CONSTANT);
+      let module = load_naga_module_from_path(
+        base_dir,
+        entry_point,
+        &mut composer,
+        shader_defs,
+        load_file,
+      )
+      .map_err(|e| naga_oil::compose::ComposerError {
+        inner: naga_oil::compose::ComposerErrorInner::ImportNotFound(e, 0),
+        source: naga_oil::compose::ErrSource::Constructing {
+          path: "load_naga_module_from_path".to_string(),
+          source: "Generated code".to_string(),
+          offset: 0,
+        },
+      })?;
+      let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("main.wgsl"),
+        source: wgpu::ShaderSource::Naga(std::borrow::Cow::Owned(module)),
+      });
+      Ok(shader_module)
+    }
   }
 }
 pub mod bytemuck_impls {
   use super::{_root, _root::*};
-  unsafe impl bytemuck::Zeroable for main::Style {}
-  unsafe impl bytemuck::Pod for main::Style {}
+  unsafe impl bytemuck::Zeroable for basic::main::Style {}
+  unsafe impl bytemuck::Pod for basic::main::Style {}
 }
 pub mod bindings {
   use super::{_root, _root::*};

--- a/wgsl_bindgen/tests/snapshots/module_path_binding_generation.snap
+++ b/wgsl_bindgen/tests/snapshots/module_path_binding_generation.snap
@@ -1,0 +1,316 @@
+---
+source: wgsl_bindgen/tests/issues_tests.rs
+---
+#![allow(unused, non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ShaderEntry {
+  LinesSegment,
+}
+impl ShaderEntry {
+  pub fn create_pipeline_layout(&self, device: &wgpu::Device) -> wgpu::PipelineLayout {
+    match self {
+      Self::LinesSegment => lines::segment::create_pipeline_layout(device),
+    }
+  }
+  pub fn create_shader_module_embed_source(
+    &self,
+    device: &wgpu::Device,
+  ) -> wgpu::ShaderModule {
+    match self {
+      Self::LinesSegment => lines::segment::create_shader_module_embed_source(device),
+    }
+  }
+}
+mod _root {
+  pub use super::*;
+  pub trait SetBindGroup {
+    fn set_bind_group(
+      &mut self,
+      index: u32,
+      bind_group: &wgpu::BindGroup,
+      offsets: &[wgpu::DynamicOffset],
+    );
+  }
+  impl SetBindGroup for wgpu::RenderPass<'_> {
+    fn set_bind_group(
+      &mut self,
+      index: u32,
+      bind_group: &wgpu::BindGroup,
+      offsets: &[wgpu::DynamicOffset],
+    ) {
+      self.set_bind_group(index, bind_group, offsets);
+    }
+  }
+  impl SetBindGroup for wgpu::RenderBundleEncoder<'_> {
+    fn set_bind_group(
+      &mut self,
+      index: u32,
+      bind_group: &wgpu::BindGroup,
+      offsets: &[wgpu::DynamicOffset],
+    ) {
+      self.set_bind_group(index, bind_group, offsets);
+    }
+  }
+}
+pub mod layout_asserts {
+  use super::{_root, _root::*};
+  const WGSL_BASE_TYPE_ASSERTS: () = {
+    assert!(std::mem::size_of::<glam::IVec2>() == 8);
+    assert!(std::mem::align_of::<glam::IVec2>() == 4);
+    assert!(std::mem::size_of::<glam::IVec3>() == 12);
+    assert!(std::mem::align_of::<glam::IVec3>() == 4);
+    assert!(std::mem::size_of::<glam::IVec4>() == 16);
+    assert!(std::mem::align_of::<glam::IVec4>() == 4);
+    assert!(std::mem::size_of::<glam::UVec2>() == 8);
+    assert!(std::mem::align_of::<glam::UVec2>() == 4);
+    assert!(std::mem::size_of::<glam::UVec3>() == 12);
+    assert!(std::mem::align_of::<glam::UVec3>() == 4);
+    assert!(std::mem::size_of::<glam::UVec4>() == 16);
+    assert!(std::mem::align_of::<glam::UVec4>() == 4);
+    assert!(std::mem::size_of::<glam::Vec2>() == 8);
+    assert!(std::mem::align_of::<glam::Vec2>() == 4);
+    assert!(std::mem::size_of::<glam::Vec3>() == 12);
+    assert!(std::mem::align_of::<glam::Vec3>() == 4);
+    assert!(std::mem::size_of::<glam::Vec4>() == 16);
+    assert!(std::mem::align_of::<glam::Vec4>() == 16);
+    assert!(std::mem::size_of::<glam::Mat2>() == 16);
+    assert!(std::mem::align_of::<glam::Mat2>() == 16);
+    assert!(std::mem::size_of::<glam::Mat3A>() == 48);
+    assert!(std::mem::align_of::<glam::Mat3A>() == 16);
+    assert!(std::mem::size_of::<glam::Mat4>() == 64);
+    assert!(std::mem::align_of::<glam::Mat4>() == 16);
+  };
+  const LINESSEGMENT_SEGMENT_DATA_ASSERTS: () = {
+    assert!(std::mem::offset_of!(lines::segment::SegmentData, start) == 0);
+    assert!(std::mem::offset_of!(lines::segment::SegmentData, end) == 8);
+    assert!(std::mem::offset_of!(lines::segment::SegmentData, color) == 16);
+    assert!(std::mem::size_of::<lines::segment::SegmentData>() == 32);
+  };
+}
+pub mod lines {
+  use super::{_root, _root::*};
+  pub mod segment {
+    use super::{_root, _root::*};
+    #[repr(C, align(16))]
+    #[derive(Debug, PartialEq, Clone, Copy)]
+    pub struct SegmentData {
+      #[doc = " size: 8, offset: 0x0, type: `vec2<f32>`"]
+      pub start: glam::Vec2,
+      #[doc = " size: 8, offset: 0x8, type: `vec2<f32>`"]
+      pub end: glam::Vec2,
+      #[doc = " size: 16, offset: 0x10, type: `vec4<f32>`"]
+      pub color: glam::Vec4,
+    }
+    impl SegmentData {
+      pub const fn new(start: glam::Vec2, end: glam::Vec2, color: glam::Vec4) -> Self {
+        Self { start, end, color }
+      }
+    }
+    pub const ENTRY_VS_MAIN: &str = "vs_main";
+    pub const ENTRY_FS_MAIN: &str = "fs_main";
+    #[derive(Debug)]
+    pub struct VertexEntry<const N: usize> {
+      pub entry_point: &'static str,
+      pub buffers: [wgpu::VertexBufferLayout<'static>; N],
+      pub constants: Vec<(&'static str, f64)>,
+    }
+    pub fn vertex_state<'a, const N: usize>(
+      module: &'a wgpu::ShaderModule,
+      entry: &'a VertexEntry<N>,
+    ) -> wgpu::VertexState<'a> {
+      wgpu::VertexState {
+        module,
+        entry_point: Some(entry.entry_point),
+        buffers: &entry.buffers,
+        compilation_options: wgpu::PipelineCompilationOptions {
+          constants: &entry.constants,
+          ..Default::default()
+        },
+      }
+    }
+    pub fn vs_main_entry() -> VertexEntry<0> {
+      VertexEntry {
+        entry_point: ENTRY_VS_MAIN,
+        buffers: [],
+        constants: Default::default(),
+      }
+    }
+    #[derive(Debug)]
+    pub struct FragmentEntry<const N: usize> {
+      pub entry_point: &'static str,
+      pub targets: [Option<wgpu::ColorTargetState>; N],
+      pub constants: Vec<(&'static str, f64)>,
+    }
+    pub fn fragment_state<'a, const N: usize>(
+      module: &'a wgpu::ShaderModule,
+      entry: &'a FragmentEntry<N>,
+    ) -> wgpu::FragmentState<'a> {
+      wgpu::FragmentState {
+        module,
+        entry_point: Some(entry.entry_point),
+        targets: &entry.targets,
+        compilation_options: wgpu::PipelineCompilationOptions {
+          constants: &entry.constants,
+          ..Default::default()
+        },
+      }
+    }
+    pub fn fs_main_entry(
+      targets: [Option<wgpu::ColorTargetState>; 1],
+    ) -> FragmentEntry<1> {
+      FragmentEntry {
+        entry_point: ENTRY_FS_MAIN,
+        targets,
+        constants: Default::default(),
+      }
+    }
+    #[derive(Debug)]
+    pub struct WgpuBindGroup0EntriesParams<'a> {
+      pub segment: wgpu::BufferBinding<'a>,
+    }
+    #[derive(Clone, Debug)]
+    pub struct WgpuBindGroup0Entries<'a> {
+      pub segment: wgpu::BindGroupEntry<'a>,
+    }
+    impl<'a> WgpuBindGroup0Entries<'a> {
+      pub fn new(params: WgpuBindGroup0EntriesParams<'a>) -> Self {
+        Self {
+          segment: wgpu::BindGroupEntry {
+            binding: 0,
+            resource: wgpu::BindingResource::Buffer(params.segment),
+          },
+        }
+      }
+      pub fn into_array(self) -> [wgpu::BindGroupEntry<'a>; 1] {
+        [self.segment]
+      }
+      pub fn collect<B: FromIterator<wgpu::BindGroupEntry<'a>>>(self) -> B {
+        self.into_array().into_iter().collect()
+      }
+    }
+    #[derive(Debug)]
+    pub struct WgpuBindGroup0(wgpu::BindGroup);
+    impl WgpuBindGroup0 {
+      pub const LAYOUT_DESCRIPTOR: wgpu::BindGroupLayoutDescriptor<'static> =
+        wgpu::BindGroupLayoutDescriptor {
+          label: Some("LinesSegment::BindGroup0::LayoutDescriptor"),
+          entries: &[
+            #[doc = " @binding(0): \"segment\""]
+            wgpu::BindGroupLayoutEntry {
+              binding: 0,
+              visibility: wgpu::ShaderStages::VERTEX_FRAGMENT,
+              ty: wgpu::BindingType::Buffer {
+                ty: wgpu::BufferBindingType::Uniform,
+                has_dynamic_offset: false,
+                min_binding_size: std::num::NonZeroU64::new(std::mem::size_of::<
+                  _root::lines::segment::SegmentData,
+                >() as _),
+              },
+              count: None,
+            },
+          ],
+        };
+      pub fn get_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
+        device.create_bind_group_layout(&Self::LAYOUT_DESCRIPTOR)
+      }
+      pub fn from_bindings(
+        device: &wgpu::Device,
+        bindings: WgpuBindGroup0Entries,
+      ) -> Self {
+        let bind_group_layout = Self::get_bind_group_layout(device);
+        let entries = bindings.into_array();
+        let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+          label: Some("LinesSegment::BindGroup0"),
+          layout: &bind_group_layout,
+          entries: &entries,
+        });
+        Self(bind_group)
+      }
+      pub fn set(&self, pass: &mut impl SetBindGroup) {
+        pass.set_bind_group(0, &self.0, &[]);
+      }
+    }
+    #[doc = " Bind groups can be set individually using their set(render_pass) method, or all at once using `WgpuBindGroups::set`."]
+    #[doc = " For optimal performance with many draw calls, it's recommended to organize bindings into bind groups based on update frequency:"]
+    #[doc = "   - Bind group 0: Least frequent updates (e.g. per frame resources)"]
+    #[doc = "   - Bind group 1: More frequent updates"]
+    #[doc = "   - Bind group 2: More frequent updates"]
+    #[doc = "   - Bind group 3: Most frequent updates (e.g. per draw resources)"]
+    #[derive(Debug, Copy, Clone)]
+    pub struct WgpuBindGroups<'a> {
+      pub bind_group0: &'a WgpuBindGroup0,
+    }
+    impl<'a> WgpuBindGroups<'a> {
+      pub fn set(&self, pass: &mut impl SetBindGroup) {
+        self.bind_group0.set(pass);
+      }
+    }
+    #[derive(Debug)]
+    pub struct WgpuPipelineLayout;
+    impl WgpuPipelineLayout {
+      pub fn bind_group_layout_entries(
+        entries: [wgpu::BindGroupLayout; 1],
+      ) -> [wgpu::BindGroupLayout; 1] {
+        entries
+      }
+    }
+    pub fn create_pipeline_layout(device: &wgpu::Device) -> wgpu::PipelineLayout {
+      device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("LinesSegment::PipelineLayout"),
+        bind_group_layouts: &[&WgpuBindGroup0::get_bind_group_layout(device)],
+        push_constant_ranges: &[],
+      })
+    }
+    pub fn create_shader_module_embed_source(
+      device: &wgpu::Device,
+    ) -> wgpu::ShaderModule {
+      let source = std::borrow::Cow::Borrowed(SHADER_STRING);
+      device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("segment.wgsl"),
+        source: wgpu::ShaderSource::Wgsl(source),
+      })
+    }
+    pub const SHADER_STRING: &str = r#"
+struct SegmentData {
+    start: vec2<f32>,
+    end: vec2<f32>,
+    color: vec4<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) color: vec4<f32>,
+}
+
+@group(0) @binding(0) 
+var<uniform> segment: SegmentData;
+
+@vertex 
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+    var output: VertexOutput;
+
+    if (vertex_index == 0u) {
+        let _e7 = segment.start;
+        output.position = vec4<f32>(_e7, 0f, 1f);
+    } else {
+        let _e14 = segment.end;
+        output.position = vec4<f32>(_e14, 0f, 1f);
+    }
+    let _e21 = segment.color;
+    output.color = _e21;
+    let _e22 = output;
+    return _e22;
+}
+
+@fragment 
+fn fs_main(@location(0) color: vec4<f32>) -> @location(0) vec4<f32> {
+    return color;
+}
+"#;
+  }
+}
+pub mod bytemuck_impls {
+  use super::{_root, _root::*};
+  unsafe impl bytemuck::Zeroable for lines::segment::SegmentData {}
+  unsafe impl bytemuck::Pod for lines::segment::SegmentData {}
+}

--- a/wgsl_bindgen/tests/snapshots/relative_path_bindgen.snap
+++ b/wgsl_bindgen/tests/snapshots/relative_path_bindgen.snap
@@ -4,12 +4,14 @@ source: wgsl_bindgen/tests/bindgen_tests.rs
 #![allow(unused, non_snake_case, non_camel_case_types, non_upper_case_globals)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum ShaderEntry {
-  Main,
+  TestsShadersBasicMain,
 }
 impl ShaderEntry {
   pub fn create_pipeline_layout(&self, device: &wgpu::Device) -> wgpu::PipelineLayout {
     match self {
-      Self::Main => main::create_pipeline_layout(device),
+      Self::TestsShadersBasicMain => {
+        tests::shaders::basic::main::create_pipeline_layout(device)
+      }
     }
   }
   pub fn create_shader_module_relative_path(
@@ -21,18 +23,20 @@ impl ShaderEntry {
     load_file: impl Fn(&str) -> Result<String, std::io::Error>,
   ) -> Result<wgpu::ShaderModule, naga_oil::compose::ComposerError> {
     match self {
-      Self::Main => main::create_shader_module_relative_path(
-        device,
-        base_dir,
-        *self,
-        shader_defs,
-        load_file,
-      ),
+      Self::TestsShadersBasicMain => {
+        tests::shaders::basic::main::create_shader_module_relative_path(
+          device,
+          base_dir,
+          *self,
+          shader_defs,
+          load_file,
+        )
+      }
     }
   }
   pub fn relative_path(&self) -> &'static str {
     match self {
-      Self::Main => main::SHADER_ENTRY_PATH,
+      Self::TestsShadersBasicMain => tests::shaders::basic::main::SHADER_ENTRY_PATH,
     }
   }
 }
@@ -219,273 +223,291 @@ pub mod layout_asserts {
     assert!(std::mem::size_of::<glam::Mat4>() == 64);
     assert!(std::mem::align_of::<glam::Mat4>() == 16);
   };
-  const MAIN_STYLE_ASSERTS: () = {
-    assert!(std::mem::offset_of!(main::Style, color) == 0);
-    assert!(std::mem::offset_of!(main::Style, width) == 16);
-    assert!(std::mem::size_of::<main::Style>() == 32);
+  const TESTSSHADERSBASICMAIN_STYLE_ASSERTS: () = {
+    assert!(std::mem::offset_of!(tests::shaders::basic::main::Style, color) == 0);
+    assert!(std::mem::offset_of!(tests::shaders::basic::main::Style, width) == 16);
+    assert!(std::mem::size_of::<tests::shaders::basic::main::Style>() == 32);
   };
 }
-pub mod main {
+pub mod tests {
   use super::{_root, _root::*};
-  #[repr(C, align(16))]
-  #[derive(Debug, PartialEq, Clone, Copy)]
-  pub struct Style {
-    #[doc = " size: 16, offset: 0x0, type: `vec4<f32>`"]
-    pub color: glam::Vec4,
-    #[doc = " size: 4, offset: 0x10, type: `f32`"]
-    pub width: f32,
-    pub _pad_width: [u8; 0xC],
-  }
-  impl Style {
-    pub const fn new(color: glam::Vec4, width: f32) -> Self {
-      Self {
-        color,
-        width,
-        _pad_width: [0; 0xC],
-      }
-    }
-  }
-  #[repr(C)]
-  #[derive(Debug, PartialEq, Clone, Copy)]
-  pub struct StyleInit {
-    pub color: glam::Vec4,
-    pub width: f32,
-  }
-  impl StyleInit {
-    pub const fn build(&self) -> Style {
-      Style {
-        color: self.color,
-        width: self.width,
-        _pad_width: [0; 0xC],
-      }
-    }
-  }
-  impl From<StyleInit> for Style {
-    fn from(data: StyleInit) -> Self {
-      data.build()
-    }
-  }
-  pub mod compute {
+  pub mod shaders {
     use super::{_root, _root::*};
-    pub const MAIN_WORKGROUP_SIZE: [u32; 3] = [1, 1, 1];
-    pub fn create_main_pipeline_relative_path(
-      device: &wgpu::Device,
-      base_dir: &str,
-      entry_point: ShaderEntry,
-      shader_defs: std::collections::HashMap<String, naga_oil::compose::ShaderDefValue>,
-      load_file: impl Fn(&str) -> Result<String, std::io::Error>,
-    ) -> Result<wgpu::ComputePipeline, naga_oil::compose::ComposerError> {
-      let module = super::create_shader_module_relative_path(
-        device,
-        base_dir,
-        entry_point,
-        shader_defs,
-        load_file,
-      )?;
-      let layout = super::create_pipeline_layout(device);
-      Ok(device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
-        label: Some("Compute Pipeline main"),
-        layout: Some(&layout),
-        module: &module,
-        entry_point: Some("main"),
-        compilation_options: Default::default(),
-        cache: None,
-      }))
-    }
-  }
-  pub const ENTRY_MAIN: &str = "main";
-  #[derive(Debug)]
-  pub struct WgpuBindGroup0EntriesParams<'a> {
-    pub buffer: wgpu::BufferBinding<'a>,
-    pub texture_float: &'a wgpu::TextureView,
-    pub texture_sint: &'a wgpu::TextureView,
-    pub texture_uint: &'a wgpu::TextureView,
-  }
-  #[derive(Clone, Debug)]
-  pub struct WgpuBindGroup0Entries<'a> {
-    pub buffer: wgpu::BindGroupEntry<'a>,
-    pub texture_float: wgpu::BindGroupEntry<'a>,
-    pub texture_sint: wgpu::BindGroupEntry<'a>,
-    pub texture_uint: wgpu::BindGroupEntry<'a>,
-  }
-  impl<'a> WgpuBindGroup0Entries<'a> {
-    pub fn new(params: WgpuBindGroup0EntriesParams<'a>) -> Self {
-      Self {
-        buffer: wgpu::BindGroupEntry {
-          binding: 0,
-          resource: wgpu::BindingResource::Buffer(params.buffer),
-        },
-        texture_float: wgpu::BindGroupEntry {
-          binding: 1,
-          resource: wgpu::BindingResource::TextureView(params.texture_float),
-        },
-        texture_sint: wgpu::BindGroupEntry {
-          binding: 2,
-          resource: wgpu::BindingResource::TextureView(params.texture_sint),
-        },
-        texture_uint: wgpu::BindGroupEntry {
-          binding: 3,
-          resource: wgpu::BindingResource::TextureView(params.texture_uint),
-        },
+    pub mod basic {
+      use super::{_root, _root::*};
+      pub mod main {
+        use super::{_root, _root::*};
+        #[repr(C, align(16))]
+        #[derive(Debug, PartialEq, Clone, Copy)]
+        pub struct Style {
+          #[doc = " size: 16, offset: 0x0, type: `vec4<f32>`"]
+          pub color: glam::Vec4,
+          #[doc = " size: 4, offset: 0x10, type: `f32`"]
+          pub width: f32,
+          pub _pad_width: [u8; 0xC],
+        }
+        impl Style {
+          pub const fn new(color: glam::Vec4, width: f32) -> Self {
+            Self {
+              color,
+              width,
+              _pad_width: [0; 0xC],
+            }
+          }
+        }
+        #[repr(C)]
+        #[derive(Debug, PartialEq, Clone, Copy)]
+        pub struct StyleInit {
+          pub color: glam::Vec4,
+          pub width: f32,
+        }
+        impl StyleInit {
+          pub const fn build(&self) -> Style {
+            Style {
+              color: self.color,
+              width: self.width,
+              _pad_width: [0; 0xC],
+            }
+          }
+        }
+        impl From<StyleInit> for Style {
+          fn from(data: StyleInit) -> Self {
+            data.build()
+          }
+        }
+        pub mod compute {
+          use super::{_root, _root::*};
+          pub const MAIN_WORKGROUP_SIZE: [u32; 3] = [1, 1, 1];
+          pub fn create_main_pipeline_relative_path(
+            device: &wgpu::Device,
+            base_dir: &str,
+            entry_point: ShaderEntry,
+            shader_defs: std::collections::HashMap<
+              String,
+              naga_oil::compose::ShaderDefValue,
+            >,
+            load_file: impl Fn(&str) -> Result<String, std::io::Error>,
+          ) -> Result<wgpu::ComputePipeline, naga_oil::compose::ComposerError> {
+            let module = super::create_shader_module_relative_path(
+              device,
+              base_dir,
+              entry_point,
+              shader_defs,
+              load_file,
+            )?;
+            let layout = super::create_pipeline_layout(device);
+            Ok(device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+              label: Some("Compute Pipeline main"),
+              layout: Some(&layout),
+              module: &module,
+              entry_point: Some("main"),
+              compilation_options: Default::default(),
+              cache: None,
+            }))
+          }
+        }
+        pub const ENTRY_MAIN: &str = "main";
+        #[derive(Debug)]
+        pub struct WgpuBindGroup0EntriesParams<'a> {
+          pub buffer: wgpu::BufferBinding<'a>,
+          pub texture_float: &'a wgpu::TextureView,
+          pub texture_sint: &'a wgpu::TextureView,
+          pub texture_uint: &'a wgpu::TextureView,
+        }
+        #[derive(Clone, Debug)]
+        pub struct WgpuBindGroup0Entries<'a> {
+          pub buffer: wgpu::BindGroupEntry<'a>,
+          pub texture_float: wgpu::BindGroupEntry<'a>,
+          pub texture_sint: wgpu::BindGroupEntry<'a>,
+          pub texture_uint: wgpu::BindGroupEntry<'a>,
+        }
+        impl<'a> WgpuBindGroup0Entries<'a> {
+          pub fn new(params: WgpuBindGroup0EntriesParams<'a>) -> Self {
+            Self {
+              buffer: wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::Buffer(params.buffer),
+              },
+              texture_float: wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::TextureView(params.texture_float),
+              },
+              texture_sint: wgpu::BindGroupEntry {
+                binding: 2,
+                resource: wgpu::BindingResource::TextureView(params.texture_sint),
+              },
+              texture_uint: wgpu::BindGroupEntry {
+                binding: 3,
+                resource: wgpu::BindingResource::TextureView(params.texture_uint),
+              },
+            }
+          }
+          pub fn into_array(self) -> [wgpu::BindGroupEntry<'a>; 4] {
+            [
+              self.buffer,
+              self.texture_float,
+              self.texture_sint,
+              self.texture_uint,
+            ]
+          }
+          pub fn collect<B: FromIterator<wgpu::BindGroupEntry<'a>>>(self) -> B {
+            self.into_array().into_iter().collect()
+          }
+        }
+        #[derive(Debug)]
+        pub struct WgpuBindGroup0(wgpu::BindGroup);
+        impl WgpuBindGroup0 {
+          pub const LAYOUT_DESCRIPTOR: wgpu::BindGroupLayoutDescriptor<'static> =
+            wgpu::BindGroupLayoutDescriptor {
+              label: Some("TestsShadersBasicMain::BindGroup0::LayoutDescriptor"),
+              entries: &[
+                #[doc = " @binding(0): \"buffer\""]
+                wgpu::BindGroupLayoutEntry {
+                  binding: 0,
+                  visibility: wgpu::ShaderStages::COMPUTE,
+                  ty: wgpu::BindingType::Buffer {
+                    ty: wgpu::BufferBindingType::Storage { read_only: false },
+                    has_dynamic_offset: false,
+                    min_binding_size: None,
+                  },
+                  count: None,
+                },
+                #[doc = " @binding(1): \"texture_float\""]
+                wgpu::BindGroupLayoutEntry {
+                  binding: 1,
+                  visibility: wgpu::ShaderStages::COMPUTE,
+                  ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                  },
+                  count: None,
+                },
+                #[doc = " @binding(2): \"texture_sint\""]
+                wgpu::BindGroupLayoutEntry {
+                  binding: 2,
+                  visibility: wgpu::ShaderStages::COMPUTE,
+                  ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Sint,
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                  },
+                  count: None,
+                },
+                #[doc = " @binding(3): \"texture_uint\""]
+                wgpu::BindGroupLayoutEntry {
+                  binding: 3,
+                  visibility: wgpu::ShaderStages::COMPUTE,
+                  ty: wgpu::BindingType::Texture {
+                    sample_type: wgpu::TextureSampleType::Uint,
+                    view_dimension: wgpu::TextureViewDimension::D2,
+                    multisampled: false,
+                  },
+                  count: None,
+                },
+              ],
+            };
+          pub fn get_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
+            device.create_bind_group_layout(&Self::LAYOUT_DESCRIPTOR)
+          }
+          pub fn from_bindings(
+            device: &wgpu::Device,
+            bindings: WgpuBindGroup0Entries,
+          ) -> Self {
+            let bind_group_layout = Self::get_bind_group_layout(device);
+            let entries = bindings.into_array();
+            let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
+              label: Some("TestsShadersBasicMain::BindGroup0"),
+              layout: &bind_group_layout,
+              entries: &entries,
+            });
+            Self(bind_group)
+          }
+          pub fn set(&self, pass: &mut impl SetBindGroup) {
+            pass.set_bind_group(0, &self.0, &[]);
+          }
+        }
+        #[doc = " Bind groups can be set individually using their set(render_pass) method, or all at once using `WgpuBindGroups::set`."]
+        #[doc = " For optimal performance with many draw calls, it's recommended to organize bindings into bind groups based on update frequency:"]
+        #[doc = "   - Bind group 0: Least frequent updates (e.g. per frame resources)"]
+        #[doc = "   - Bind group 1: More frequent updates"]
+        #[doc = "   - Bind group 2: More frequent updates"]
+        #[doc = "   - Bind group 3: Most frequent updates (e.g. per draw resources)"]
+        #[derive(Debug, Copy, Clone)]
+        pub struct WgpuBindGroups<'a> {
+          pub bind_group0: &'a WgpuBindGroup0,
+          pub bind_group1: &'a bindings::WgpuBindGroup1,
+        }
+        impl<'a> WgpuBindGroups<'a> {
+          pub fn set(&self, pass: &mut impl SetBindGroup) {
+            self.bind_group0.set(pass);
+            self.bind_group1.set(pass);
+          }
+        }
+        #[derive(Debug)]
+        pub struct WgpuPipelineLayout;
+        impl WgpuPipelineLayout {
+          pub fn bind_group_layout_entries(
+            entries: [wgpu::BindGroupLayout; 2],
+          ) -> [wgpu::BindGroupLayout; 2] {
+            entries
+          }
+        }
+        pub fn create_pipeline_layout(device: &wgpu::Device) -> wgpu::PipelineLayout {
+          device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+            label: Some("TestsShadersBasicMain::PipelineLayout"),
+            bind_group_layouts: &[
+              &WgpuBindGroup0::get_bind_group_layout(device),
+              &bindings::WgpuBindGroup1::get_bind_group_layout(device),
+            ],
+            push_constant_ranges: &[wgpu::PushConstantRange {
+              stages: wgpu::ShaderStages::COMPUTE,
+              range: 0..32,
+            }],
+          })
+        }
+        pub const SHADER_ENTRY_PATH: &str = "../basic/main.wgsl";
+        pub fn create_shader_module_relative_path(
+          device: &wgpu::Device,
+          base_dir: &str,
+          entry_point: ShaderEntry,
+          shader_defs: std::collections::HashMap<
+            String,
+            naga_oil::compose::ShaderDefValue,
+          >,
+          load_file: impl Fn(&str) -> Result<String, std::io::Error>,
+        ) -> Result<wgpu::ShaderModule, naga_oil::compose::ComposerError> {
+          let mut composer = naga_oil::compose::Composer::default()
+            .with_capabilities(wgpu::naga::valid::Capabilities::PUSH_CONSTANT);
+          let module = load_naga_module_from_path(
+            base_dir,
+            entry_point,
+            &mut composer,
+            shader_defs,
+            load_file,
+          )
+          .map_err(|e| naga_oil::compose::ComposerError {
+            inner: naga_oil::compose::ComposerErrorInner::ImportNotFound(e, 0),
+            source: naga_oil::compose::ErrSource::Constructing {
+              path: "load_naga_module_from_path".to_string(),
+              source: "Generated code".to_string(),
+              offset: 0,
+            },
+          })?;
+          let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("main.wgsl"),
+            source: wgpu::ShaderSource::Naga(std::borrow::Cow::Owned(module)),
+          });
+          Ok(shader_module)
+        }
       }
     }
-    pub fn into_array(self) -> [wgpu::BindGroupEntry<'a>; 4] {
-      [
-        self.buffer,
-        self.texture_float,
-        self.texture_sint,
-        self.texture_uint,
-      ]
-    }
-    pub fn collect<B: FromIterator<wgpu::BindGroupEntry<'a>>>(self) -> B {
-      self.into_array().into_iter().collect()
-    }
-  }
-  #[derive(Debug)]
-  pub struct WgpuBindGroup0(wgpu::BindGroup);
-  impl WgpuBindGroup0 {
-    pub const LAYOUT_DESCRIPTOR: wgpu::BindGroupLayoutDescriptor<'static> =
-      wgpu::BindGroupLayoutDescriptor {
-        label: Some("Main::BindGroup0::LayoutDescriptor"),
-        entries: &[
-          #[doc = " @binding(0): \"buffer\""]
-          wgpu::BindGroupLayoutEntry {
-            binding: 0,
-            visibility: wgpu::ShaderStages::COMPUTE,
-            ty: wgpu::BindingType::Buffer {
-              ty: wgpu::BufferBindingType::Storage { read_only: false },
-              has_dynamic_offset: false,
-              min_binding_size: None,
-            },
-            count: None,
-          },
-          #[doc = " @binding(1): \"texture_float\""]
-          wgpu::BindGroupLayoutEntry {
-            binding: 1,
-            visibility: wgpu::ShaderStages::COMPUTE,
-            ty: wgpu::BindingType::Texture {
-              sample_type: wgpu::TextureSampleType::Float { filterable: true },
-              view_dimension: wgpu::TextureViewDimension::D2,
-              multisampled: false,
-            },
-            count: None,
-          },
-          #[doc = " @binding(2): \"texture_sint\""]
-          wgpu::BindGroupLayoutEntry {
-            binding: 2,
-            visibility: wgpu::ShaderStages::COMPUTE,
-            ty: wgpu::BindingType::Texture {
-              sample_type: wgpu::TextureSampleType::Sint,
-              view_dimension: wgpu::TextureViewDimension::D2,
-              multisampled: false,
-            },
-            count: None,
-          },
-          #[doc = " @binding(3): \"texture_uint\""]
-          wgpu::BindGroupLayoutEntry {
-            binding: 3,
-            visibility: wgpu::ShaderStages::COMPUTE,
-            ty: wgpu::BindingType::Texture {
-              sample_type: wgpu::TextureSampleType::Uint,
-              view_dimension: wgpu::TextureViewDimension::D2,
-              multisampled: false,
-            },
-            count: None,
-          },
-        ],
-      };
-    pub fn get_bind_group_layout(device: &wgpu::Device) -> wgpu::BindGroupLayout {
-      device.create_bind_group_layout(&Self::LAYOUT_DESCRIPTOR)
-    }
-    pub fn from_bindings(device: &wgpu::Device, bindings: WgpuBindGroup0Entries) -> Self {
-      let bind_group_layout = Self::get_bind_group_layout(device);
-      let entries = bindings.into_array();
-      let bind_group = device.create_bind_group(&wgpu::BindGroupDescriptor {
-        label: Some("Main::BindGroup0"),
-        layout: &bind_group_layout,
-        entries: &entries,
-      });
-      Self(bind_group)
-    }
-    pub fn set(&self, pass: &mut impl SetBindGroup) {
-      pass.set_bind_group(0, &self.0, &[]);
-    }
-  }
-  #[doc = " Bind groups can be set individually using their set(render_pass) method, or all at once using `WgpuBindGroups::set`."]
-  #[doc = " For optimal performance with many draw calls, it's recommended to organize bindings into bind groups based on update frequency:"]
-  #[doc = "   - Bind group 0: Least frequent updates (e.g. per frame resources)"]
-  #[doc = "   - Bind group 1: More frequent updates"]
-  #[doc = "   - Bind group 2: More frequent updates"]
-  #[doc = "   - Bind group 3: Most frequent updates (e.g. per draw resources)"]
-  #[derive(Debug, Copy, Clone)]
-  pub struct WgpuBindGroups<'a> {
-    pub bind_group0: &'a WgpuBindGroup0,
-    pub bind_group1: &'a bindings::WgpuBindGroup1,
-  }
-  impl<'a> WgpuBindGroups<'a> {
-    pub fn set(&self, pass: &mut impl SetBindGroup) {
-      self.bind_group0.set(pass);
-      self.bind_group1.set(pass);
-    }
-  }
-  #[derive(Debug)]
-  pub struct WgpuPipelineLayout;
-  impl WgpuPipelineLayout {
-    pub fn bind_group_layout_entries(
-      entries: [wgpu::BindGroupLayout; 2],
-    ) -> [wgpu::BindGroupLayout; 2] {
-      entries
-    }
-  }
-  pub fn create_pipeline_layout(device: &wgpu::Device) -> wgpu::PipelineLayout {
-    device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
-      label: Some("Main::PipelineLayout"),
-      bind_group_layouts: &[
-        &WgpuBindGroup0::get_bind_group_layout(device),
-        &bindings::WgpuBindGroup1::get_bind_group_layout(device),
-      ],
-      push_constant_ranges: &[wgpu::PushConstantRange {
-        stages: wgpu::ShaderStages::COMPUTE,
-        range: 0..32,
-      }],
-    })
-  }
-  pub const SHADER_ENTRY_PATH: &str = "../basic/main.wgsl";
-  pub fn create_shader_module_relative_path(
-    device: &wgpu::Device,
-    base_dir: &str,
-    entry_point: ShaderEntry,
-    shader_defs: std::collections::HashMap<String, naga_oil::compose::ShaderDefValue>,
-    load_file: impl Fn(&str) -> Result<String, std::io::Error>,
-  ) -> Result<wgpu::ShaderModule, naga_oil::compose::ComposerError> {
-    let mut composer = naga_oil::compose::Composer::default()
-      .with_capabilities(wgpu::naga::valid::Capabilities::PUSH_CONSTANT);
-    let module = load_naga_module_from_path(
-      base_dir,
-      entry_point,
-      &mut composer,
-      shader_defs,
-      load_file,
-    )
-    .map_err(|e| naga_oil::compose::ComposerError {
-      inner: naga_oil::compose::ComposerErrorInner::ImportNotFound(e, 0),
-      source: naga_oil::compose::ErrSource::Constructing {
-        path: "load_naga_module_from_path".to_string(),
-        source: "Generated code".to_string(),
-        offset: 0,
-      },
-    })?;
-    let shader_module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
-      label: Some("main.wgsl"),
-      source: wgpu::ShaderSource::Naga(std::borrow::Cow::Owned(module)),
-    });
-    Ok(shader_module)
   }
 }
 pub mod bytemuck_impls {
   use super::{_root, _root::*};
-  unsafe impl bytemuck::Zeroable for main::Style {}
-  unsafe impl bytemuck::Pod for main::Style {}
+  unsafe impl bytemuck::Zeroable for tests::shaders::basic::main::Style {}
+  unsafe impl bytemuck::Pod for tests::shaders::basic::main::Style {}
 }
 pub mod bindings {
   use super::{_root, _root::*};


### PR DESCRIPTION
Pull Request Message

  # Fix: Generate correct module paths for nested shader files

  ## Problem

  When shader entrypoints are inside subdirectories like `lines/segment.wgsl`, the generated bindings were incorrect:

  - **Module**: Generated as `segment` instead of `lines::segment`
  - **ShaderEntry variant**: Generated as `Segment` instead of `LinesSegment`

  This caused naming conflicts when multiple shaders in different directories had the same filename, and made the module structure not reflect the actual file organization.

  ## Solution

  ### Core Changes

  1. **Enhanced path-to-module conversion**: Added `module_path()` and `path_to_module_path()` methods to `SourceFilePath` that properly convert file paths to Rust module paths
  relative to workspace root.

  2. **Fixed enum variant naming**: Updated `sanitize_and_pascal_case()` to handle module paths with `::` separators by replacing them with `_` before conversion to PascalCase.

  3. **Improved shader registry generation**: Updated all functions in `shader_registry.rs` to properly split module paths and generate correct Rust path references.

  ### Example

  **Before:**
  ```wgsl
  // File: shaders/lines/segment.wgsl
  Generated:
  pub mod segment { ... }
  pub enum ShaderEntry { Segment }
  // Usage: segment::create_pipeline_layout(device)

  After:
  // File: shaders/lines/segment.wgsl
  Generated:
  pub mod lines {
    pub mod segment { ... }
  }
  pub enum ShaderEntry { LinesSegment }
  // Usage: lines::segment::create_pipeline_layout(device)

  Files Changed

  - src/types.rs: Added module path conversion utilities
  - src/lib.rs: Enhanced sanitize_and_pascal_case() for module paths
  - src/bindgen/wgsl_bindgen_impl.rs: Use new module path generation
  - src/generate/shader_registry.rs: Handle nested module references
  - tests/issues_tests.rs: Added comprehensive integration test
  - example/src/demos/particle_compute_demo.rs: Updated to use new module structure

  Testing

  - ✅ New integration test test_module_path_binding_generation validates the fix
  - ✅ All existing tests continue to pass
  - ✅ Example builds and runs successfully with updated imports
  - ✅ Generated code compiles and passes rust compilation checks

  Breaking Changes

  This is a breaking change for projects using shaders in subdirectories. Users will need to update their imports:

  // Before
  use crate::shader_bindings::particle_physics;
  shader_bindings::ShaderEntry::ParticlePhysics

  // After  
  use crate::shader_bindings::compute_demo::particle_physics;
  shader_bindings::ShaderEntry::ComputeDemoParticlePhysics

  Migration Guide

  For shaders in subdirectories, update imports to include the full module path:
  1. Add directory names to import paths: module_name → directory::module_name
  2. Update ShaderEntry variants: VariantName → DirectoryVariantName

  Shaders at the root level are unaffected.