### PR TITLE
Add Init Struct Generation and Improve Field Documentation

### DIFF
--- a/example/src/shader_bindings.rs
+++ b/example/src/shader_bindings.rs
@@ -356,13 +356,13 @@ pub mod global_bindings {
   #[repr(C, align(8))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct GlobalUniforms {
-    #[doc = " size: 4, offset: 0x0, type: `f32`"]
+    #[doc = "offset: 0, size: 4, type: `f32`"]
     pub time: f32,
-    #[doc = " size: 4, offset: 0x4, type: `f32`"]
+    #[doc = "offset: 4, size: 4, type: `f32`"]
     pub scale_factor: f32,
-    #[doc = " size: 8, offset: 0x8, type: `vec2<f32>`"]
+    #[doc = "offset: 8, size: 8, type: `vec2<f32>`"]
     pub frame_size: glam::Vec2,
-    #[doc = " size: 8, offset: 0x10, type: `vec2<f32>`"]
+    #[doc = "offset: 16, size: 8, type: `vec2<f32>`"]
     pub mouse_pos: glam::Vec2,
   }
   impl GlobalUniforms {
@@ -478,7 +478,7 @@ pub mod fullscreen_effects {
   #[repr(C, align(16))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct Uniforms {
-    #[doc = " size: 16, offset: 0x0, type: `vec4<f32>`"]
+    #[doc = "offset: 0, size: 16, type: `vec4<f32>`"]
     pub color_rgb: glam::Vec4,
   }
   pub const fn Uniforms(color_rgb: glam::Vec4) -> Uniforms {
@@ -511,7 +511,7 @@ pub mod fullscreen_effects {
   #[repr(C, align(16))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct PushConstants {
-    #[doc = " size: 64, offset: 0x0, type: `mat4x4<f32>`"]
+    #[doc = "offset: 0, size: 64, type: `mat4x4<f32>`"]
     pub color_matrix: glam::Mat4,
   }
   pub const fn PushConstants(color_matrix: glam::Mat4) -> PushConstants {
@@ -789,7 +789,7 @@ pub mod simple_array_demo {
   #[repr(C, align(16))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct Uniforms {
-    #[doc = " size: 16, offset: 0x0, type: `vec4<f32>`"]
+    #[doc = "offset: 0, size: 16, type: `vec4<f32>`"]
     pub color_rgb: glam::Vec4,
   }
   pub const fn Uniforms(color_rgb: glam::Vec4) -> Uniforms {
@@ -822,7 +822,7 @@ pub mod simple_array_demo {
   #[repr(C, align(16))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct PushConstants {
-    #[doc = " size: 64, offset: 0x0, type: `mat4x4<f32>`"]
+    #[doc = "offset: 0, size: 64, type: `mat4x4<f32>`"]
     pub color_matrix: glam::Mat4,
   }
   pub const fn PushConstants(color_matrix: glam::Mat4) -> PushConstants {
@@ -1100,21 +1100,21 @@ pub mod overlay {
   #[repr(C, align(4))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct InfoData {
-    #[doc = " size: 4, offset: 0x0, type: `f32`"]
+    #[doc = "offset: 0, size: 4, type: `f32`"]
     pub demo_index: f32,
-    #[doc = " size: 4, offset: 0x4, type: `f32`"]
+    #[doc = "offset: 4, size: 4, type: `f32`"]
     pub total_demos: f32,
-    #[doc = " size: 4, offset: 0x8, type: `f32`"]
+    #[doc = "offset: 8, size: 4, type: `f32`"]
     pub time: f32,
-    #[doc = " size: 4, offset: 0xC, type: `f32`"]
+    #[doc = "offset: 12, size: 4, type: `f32`"]
     pub scale_factor: f32,
-    #[doc = " size: 4, offset: 0x10, type: `f32`"]
+    #[doc = "offset: 16, size: 4, type: `f32`"]
     pub window_width: f32,
-    #[doc = " size: 4, offset: 0x14, type: `f32`"]
+    #[doc = "offset: 20, size: 4, type: `f32`"]
     pub window_height: f32,
-    #[doc = " size: 4, offset: 0x18, type: `f32`"]
+    #[doc = "offset: 24, size: 4, type: `f32`"]
     pub padding1: f32,
-    #[doc = " size: 4, offset: 0x1C, type: `f32`"]
+    #[doc = "offset: 28, size: 4, type: `f32`"]
     pub padding2: f32,
   }
   impl InfoData {
@@ -1500,15 +1500,15 @@ pub mod compute_demo {
     #[repr(C, align(16))]
     #[derive(Debug, PartialEq, Clone, Copy)]
     pub struct Job {
-      #[doc = " size: 12, offset: 0x0, type: `vec3<f32>`"]
+      #[doc = "offset: 0, size: 12, type: `vec3<f32>`"]
       pub position: glam::Vec3,
       pub _pad_position: [u8; 0x4],
-      #[doc = " size: 12, offset: 0x10, type: `vec3<f32>`"]
+      #[doc = "offset: 16, size: 12, type: `vec3<f32>`"]
       pub direction: glam::Vec3,
       pub _pad_direction: [u8; 0x4],
-      #[doc = " size: 12, offset: 0x20, type: `vec3<f32>`"]
+      #[doc = "offset: 32, size: 12, type: `vec3<f32>`"]
       pub accum: glam::Vec3,
-      #[doc = " size: 4, offset: 0x2C, type: `u32`"]
+      #[doc = "offset: 44, size: 4, type: `u32`"]
       pub depth: u32,
     }
     impl Job {
@@ -1537,7 +1537,7 @@ pub mod compute_demo {
       pub depth: u32,
     }
     impl JobInit {
-      pub const fn build(&self) -> Job {
+      pub fn build(&self) -> Job {
         Job {
           position: self.position,
           _pad_position: [0; 0x4],
@@ -1556,9 +1556,9 @@ pub mod compute_demo {
     #[repr(C, align(4))]
     #[derive(Debug, PartialEq, Clone, Copy)]
     pub struct Params {
-      #[doc = " size: 4, offset: 0x0, type: `f32`"]
+      #[doc = "offset: 0, size: 4, type: `f32`"]
       pub scale: f32,
-      #[doc = " size: 4, offset: 0x4, type: `f32`"]
+      #[doc = "offset: 4, size: 4, type: `f32`"]
       pub damping: f32,
     }
     pub const fn Params(scale: f32, damping: f32) -> Params {

--- a/wgsl_bindgen/src/snapshots/write_all_structs_bytemuck_input_layout_validation.snap
+++ b/wgsl_bindgen/src/snapshots/write_all_structs_bytemuck_input_layout_validation.snap
@@ -4,13 +4,13 @@ source: wgsl_bindgen/src/structs.rs
 #[repr(C, align(4))]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Input0 {
-  #[doc = " size: 4, offset: 0x0, type: `u32`"]
+  #[doc = "offset: 0, size: 4, type: `u32`"]
   pub a: u32,
   pub _pad_a: [u8; 0x4],
-  #[doc = " size: 4, offset: 0x8, type: `i32`"]
+  #[doc = "offset: 8, size: 4, type: `i32`"]
   pub b: i32,
   pub _pad_b: [u8; 0x14],
-  #[doc = " size: 4, offset: 0x20, type: `f32`"]
+  #[doc = "offset: 32, size: 4, type: `f32`"]
   pub c: f32,
   pub _pad_d: [u8; 0x1C],
 }
@@ -34,7 +34,7 @@ pub struct Input0Init {
   pub c: f32,
 }
 impl Input0Init {
-  pub const fn build(&self) -> Input0 {
+  pub fn build(&self) -> Input0 {
     Input0 {
       a: self.a,
       _pad_a: [0; 0x4],
@@ -61,7 +61,7 @@ unsafe impl bytemuck::Pod for Input0 {}
 #[repr(C, align(4))]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Inner {
-  #[doc = " size: 4, offset: 0x0, type: `f32`"]
+  #[doc = "offset: 0, size: 4, type: `f32`"]
   pub a: f32,
 }
 impl Inner {
@@ -78,7 +78,7 @@ unsafe impl bytemuck::Pod for Inner {}
 #[repr(C, align(4))]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Outer {
-  #[doc = " size: 4, offset: 0x0, type: `Inner`"]
+  #[doc = "offset: 0, size: 4, type: `Inner`"]
   pub inner: Inner,
 }
 impl Outer {

--- a/wgsl_bindgen/src/snapshots/write_nonpower_of_2_mats.snap
+++ b/wgsl_bindgen/src/snapshots/write_nonpower_of_2_mats.snap
@@ -4,13 +4,13 @@ source: wgsl_bindgen/src/structs.rs
 #[repr(C, align(16))]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct MatricesF32 {
-  #[doc = " size: 64, offset: 0x0, type: `mat4x4<f32>`"]
+  #[doc = "offset: 0, size: 64, type: `mat4x4<f32>`"]
   pub a: [[f32; 4]; 4],
-  #[doc = " size: 64, offset: 0x40, type: `mat4x3<f32>`"]
+  #[doc = "offset: 64, size: 64, type: `mat4x3<f32>`"]
   pub b: [[f32; 4]; 4],
-  #[doc = " size: 32, offset: 0x80, type: `mat4x2<f32>`"]
+  #[doc = "offset: 128, size: 32, type: `mat4x2<f32>`"]
   pub c: [[f32; 2]; 4],
-  #[doc = " size: 48, offset: 0xA0, type: `mat3x4<f32>`"]
+  #[doc = "offset: 160, size: 48, type: `mat3x4<f32>`"]
   pub d: [[f32; 4]; 3],
 }
 impl MatricesF32 {

--- a/wgsl_bindgen/src/snapshots/write_nonpower_of_2_mats_for_bytemuck_glam_option.snap
+++ b/wgsl_bindgen/src/snapshots/write_nonpower_of_2_mats_for_bytemuck_glam_option.snap
@@ -4,7 +4,7 @@ source: wgsl_bindgen/src/structs.rs
 #[repr(C, align(16))]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct UniformsData {
-  #[doc = " size: 48, offset: 0x0, type: `mat3x3<f32>`"]
+  #[doc = "offset: 0, size: 48, type: `mat3x3<f32>`"]
   pub centered_mvp: glam::Mat3A,
 }
 impl UniformsData {

--- a/wgsl_bindgen/src/snapshots/write_nonpower_of_2_mats_for_bytemuck_option.snap
+++ b/wgsl_bindgen/src/snapshots/write_nonpower_of_2_mats_for_bytemuck_option.snap
@@ -4,7 +4,7 @@ source: wgsl_bindgen/src/structs.rs
 #[repr(C, align(16))]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct UniformsData {
-  #[doc = " size: 48, offset: 0x0, type: `mat3x3<f32>`"]
+  #[doc = "offset: 0, size: 48, type: `mat3x3<f32>`"]
   pub a: [[f32; 4]; 3],
 }
 impl UniformsData {

--- a/wgsl_bindgen/src/snapshots/write_runtime_sized_array_bytemuck.snap
+++ b/wgsl_bindgen/src/snapshots/write_runtime_sized_array_bytemuck.snap
@@ -3,9 +3,9 @@ source: wgsl_bindgen/src/structs.rs
 ---
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct RtsStruct<const N: usize> {
-  #[doc = " size: 4, offset: 0x0, type: `i32`"]
+  #[doc = "offset: 0, size: 4, type: `i32`"]
   pub other_data: i32,
-  #[doc = " size: 4, offset: 0x4, type: `array<u32>`"]
+  #[doc = "offset: 4, size: 4, type: `array<u32>`"]
   pub the_array: [u32; N],
 }
 impl<const N: usize> RtsStruct<N> {

--- a/wgsl_bindgen/src/snapshots/write_shorter_constructor.snap
+++ b/wgsl_bindgen/src/snapshots/write_shorter_constructor.snap
@@ -4,7 +4,7 @@ source: wgsl_bindgen/src/structs.rs
 #[repr(C, align(8))]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub struct Uniform {
-  #[doc = " size: 8, offset: 0x0, type: `vec2<f32>`"]
+  #[doc = "offset: 0, size: 8, type: `vec2<f32>`"]
   pub position_data: glam::Vec2,
 }
 pub const fn Uniform(position_data: glam::Vec2) -> Uniform {

--- a/wgsl_bindgen/tests/snapshots/bevy_bindgen.snap
+++ b/wgsl_bindgen/tests/snapshots/bevy_bindgen.snap
@@ -256,19 +256,19 @@ pub mod bevy_pbr {
       #[repr(C, align(16))]
       #[derive(Debug, PartialEq, Clone, Copy)]
       pub struct StandardMaterial {
-        #[doc = " size: 16, offset: 0x0, type: `vec4<f32>`"]
+        #[doc = "offset: 0, size: 16, type: `vec4<f32>`"]
         pub base_color: glam::Vec4,
-        #[doc = " size: 16, offset: 0x10, type: `vec4<f32>`"]
+        #[doc = "offset: 16, size: 16, type: `vec4<f32>`"]
         pub emissive: glam::Vec4,
-        #[doc = " size: 4, offset: 0x20, type: `f32`"]
+        #[doc = "offset: 32, size: 4, type: `f32`"]
         pub perceptual_roughness: f32,
-        #[doc = " size: 4, offset: 0x24, type: `f32`"]
+        #[doc = "offset: 36, size: 4, type: `f32`"]
         pub metallic: f32,
-        #[doc = " size: 4, offset: 0x28, type: `f32`"]
+        #[doc = "offset: 40, size: 4, type: `f32`"]
         pub reflectance: f32,
-        #[doc = " size: 4, offset: 0x2C, type: `u32`"]
+        #[doc = "offset: 44, size: 4, type: `u32`"]
         pub flags: u32,
-        #[doc = " size: 4, offset: 0x30, type: `f32`"]
+        #[doc = "offset: 48, size: 4, type: `f32`"]
         pub alpha_cutoff: f32,
         pub _pad_alpha_cutoff: [u8; 0xC],
       }
@@ -306,7 +306,7 @@ pub mod bevy_pbr {
         pub alpha_cutoff: f32,
       }
       impl StandardMaterialInit {
-        pub const fn build(&self) -> StandardMaterial {
+        pub fn build(&self) -> StandardMaterial {
           StandardMaterial {
             base_color: self.base_color,
             emissive: self.emissive,
@@ -404,23 +404,23 @@ pub mod bevy_pbr {
     #[repr(C, align(16))]
     #[derive(Debug, PartialEq, Clone, Copy)]
     pub struct View {
-      #[doc = " size: 64, offset: 0x0, type: `mat4x4<f32>`"]
+      #[doc = "offset: 0, size: 64, type: `mat4x4<f32>`"]
       pub view_proj: glam::Mat4,
-      #[doc = " size: 64, offset: 0x40, type: `mat4x4<f32>`"]
+      #[doc = "offset: 64, size: 64, type: `mat4x4<f32>`"]
       pub inverse_view_proj: glam::Mat4,
-      #[doc = " size: 64, offset: 0x80, type: `mat4x4<f32>`"]
+      #[doc = "offset: 128, size: 64, type: `mat4x4<f32>`"]
       pub view: glam::Mat4,
-      #[doc = " size: 64, offset: 0xC0, type: `mat4x4<f32>`"]
+      #[doc = "offset: 192, size: 64, type: `mat4x4<f32>`"]
       pub inverse_view: glam::Mat4,
-      #[doc = " size: 64, offset: 0x100, type: `mat4x4<f32>`"]
+      #[doc = "offset: 256, size: 64, type: `mat4x4<f32>`"]
       pub projection: glam::Mat4,
-      #[doc = " size: 64, offset: 0x140, type: `mat4x4<f32>`"]
+      #[doc = "offset: 320, size: 64, type: `mat4x4<f32>`"]
       pub inverse_projection: glam::Mat4,
-      #[doc = " size: 12, offset: 0x180, type: `vec3<f32>`"]
+      #[doc = "offset: 384, size: 12, type: `vec3<f32>`"]
       pub world_position: glam::Vec3,
-      #[doc = " size: 4, offset: 0x18C, type: `f32`"]
+      #[doc = "offset: 396, size: 4, type: `f32`"]
       pub width: f32,
-      #[doc = " size: 4, offset: 0x190, type: `f32`"]
+      #[doc = "offset: 400, size: 4, type: `f32`"]
       pub height: f32,
       pub _pad_height: [u8; 0xC],
     }
@@ -464,7 +464,7 @@ pub mod bevy_pbr {
       pub height: f32,
     }
     impl ViewInit {
-      pub const fn build(&self) -> View {
+      pub fn build(&self) -> View {
         View {
           view_proj: self.view_proj,
           inverse_view_proj: self.inverse_view_proj,
@@ -487,17 +487,17 @@ pub mod bevy_pbr {
     #[repr(C, align(16))]
     #[derive(Debug, PartialEq, Clone, Copy)]
     pub struct DirectionalLight {
-      #[doc = " size: 64, offset: 0x0, type: `mat4x4<f32>`"]
+      #[doc = "offset: 0, size: 64, type: `mat4x4<f32>`"]
       pub view_projection: glam::Mat4,
-      #[doc = " size: 16, offset: 0x40, type: `vec4<f32>`"]
+      #[doc = "offset: 64, size: 16, type: `vec4<f32>`"]
       pub color: glam::Vec4,
-      #[doc = " size: 12, offset: 0x50, type: `vec3<f32>`"]
+      #[doc = "offset: 80, size: 12, type: `vec3<f32>`"]
       pub direction_to_light: glam::Vec3,
-      #[doc = " size: 4, offset: 0x5C, type: `u32`"]
+      #[doc = "offset: 92, size: 4, type: `u32`"]
       pub flags: u32,
-      #[doc = " size: 4, offset: 0x60, type: `f32`"]
+      #[doc = "offset: 96, size: 4, type: `f32`"]
       pub shadow_depth_bias: f32,
-      #[doc = " size: 4, offset: 0x64, type: `f32`"]
+      #[doc = "offset: 100, size: 4, type: `f32`"]
       pub shadow_normal_bias: f32,
       pub _pad_shadow_normal_bias: [u8; 0x8],
     }
@@ -532,7 +532,7 @@ pub mod bevy_pbr {
       pub shadow_normal_bias: f32,
     }
     impl DirectionalLightInit {
-      pub const fn build(&self) -> DirectionalLight {
+      pub fn build(&self) -> DirectionalLight {
         DirectionalLight {
           view_projection: self.view_projection,
           color: self.color,
@@ -552,17 +552,17 @@ pub mod bevy_pbr {
     #[repr(C, align(16))]
     #[derive(Debug, PartialEq, Clone, Copy)]
     pub struct Lights {
-      #[doc = " size: 112, offset: 0x0, type: `array<bevy_pbr::mesh_view_types::DirectionalLight, 1>`"]
+      #[doc = "offset: 0, size: 112, type: `array<bevy_pbr::mesh_view_types::DirectionalLight, 1>`"]
       pub directional_lights: [_root::bevy_pbr::mesh_view_types::DirectionalLight; 1],
-      #[doc = " size: 16, offset: 0x70, type: `vec4<f32>`"]
+      #[doc = "offset: 112, size: 16, type: `vec4<f32>`"]
       pub ambient_color: glam::Vec4,
-      #[doc = " size: 16, offset: 0x80, type: `vec4<u32>`"]
+      #[doc = "offset: 128, size: 16, type: `vec4<u32>`"]
       pub cluster_dimensions: glam::UVec4,
-      #[doc = " size: 16, offset: 0x90, type: `vec4<f32>`"]
+      #[doc = "offset: 144, size: 16, type: `vec4<f32>`"]
       pub cluster_factors: glam::Vec4,
-      #[doc = " size: 4, offset: 0xA0, type: `u32`"]
+      #[doc = "offset: 160, size: 4, type: `u32`"]
       pub n_directional_lights: u32,
-      #[doc = " size: 4, offset: 0xA4, type: `i32`"]
+      #[doc = "offset: 164, size: 4, type: `i32`"]
       pub spot_light_shadowmap_offset: i32,
       pub _pad_spot_light_shadowmap_offset: [u8; 0x8],
     }
@@ -597,7 +597,7 @@ pub mod bevy_pbr {
       pub spot_light_shadowmap_offset: i32,
     }
     impl LightsInit {
-      pub const fn build(&self) -> Lights {
+      pub fn build(&self) -> Lights {
         Lights {
           directional_lights: self.directional_lights,
           ambient_color: self.ambient_color,
@@ -617,19 +617,19 @@ pub mod bevy_pbr {
     #[repr(C, align(16))]
     #[derive(Debug, PartialEq, Clone, Copy)]
     pub struct PointLight {
-      #[doc = " size: 16, offset: 0x0, type: `vec4<f32>`"]
+      #[doc = "offset: 0, size: 16, type: `vec4<f32>`"]
       pub light_custom_data: glam::Vec4,
-      #[doc = " size: 16, offset: 0x10, type: `vec4<f32>`"]
+      #[doc = "offset: 16, size: 16, type: `vec4<f32>`"]
       pub color_inverse_square_range: glam::Vec4,
-      #[doc = " size: 16, offset: 0x20, type: `vec4<f32>`"]
+      #[doc = "offset: 32, size: 16, type: `vec4<f32>`"]
       pub position_radius: glam::Vec4,
-      #[doc = " size: 4, offset: 0x30, type: `u32`"]
+      #[doc = "offset: 48, size: 4, type: `u32`"]
       pub flags: u32,
-      #[doc = " size: 4, offset: 0x34, type: `f32`"]
+      #[doc = "offset: 52, size: 4, type: `f32`"]
       pub shadow_depth_bias: f32,
-      #[doc = " size: 4, offset: 0x38, type: `f32`"]
+      #[doc = "offset: 56, size: 4, type: `f32`"]
       pub shadow_normal_bias: f32,
-      #[doc = " size: 4, offset: 0x3C, type: `f32`"]
+      #[doc = "offset: 60, size: 4, type: `f32`"]
       pub spot_light_tan_angle: f32,
     }
     impl PointLight {
@@ -655,7 +655,7 @@ pub mod bevy_pbr {
     }
     #[derive(Debug, PartialEq, Clone, Copy)]
     pub struct PointLights<const N: usize> {
-      #[doc = " size: 64, offset: 0x0, type: `array<bevy_pbr::mesh_view_types::PointLight>`"]
+      #[doc = "offset: 0, size: 64, type: `array<bevy_pbr::mesh_view_types::PointLight>`"]
       pub data: [_root::bevy_pbr::mesh_view_types::PointLight; N],
     }
     impl<const N: usize> PointLights<N> {
@@ -665,7 +665,7 @@ pub mod bevy_pbr {
     }
     #[derive(Debug, PartialEq, Clone, Copy)]
     pub struct ClusterLightIndexLists<const N: usize> {
-      #[doc = " size: 4, offset: 0x0, type: `array<u32>`"]
+      #[doc = "offset: 0, size: 4, type: `array<u32>`"]
       pub data: [u32; N],
     }
     impl<const N: usize> ClusterLightIndexLists<N> {
@@ -675,7 +675,7 @@ pub mod bevy_pbr {
     }
     #[derive(Debug, PartialEq, Clone, Copy)]
     pub struct ClusterOffsetsAndCounts<const N: usize> {
-      #[doc = " size: 16, offset: 0x0, type: `array<vec4<u32>>`"]
+      #[doc = "offset: 0, size: 16, type: `array<vec4<u32>>`"]
       pub data: [glam::UVec4; N],
     }
     impl<const N: usize> ClusterOffsetsAndCounts<N> {
@@ -692,11 +692,11 @@ pub mod bevy_pbr {
     #[repr(C, align(16))]
     #[derive(Debug, PartialEq, Clone, Copy)]
     pub struct Mesh {
-      #[doc = " size: 64, offset: 0x0, type: `mat4x4<f32>`"]
+      #[doc = "offset: 0, size: 64, type: `mat4x4<f32>`"]
       pub model: glam::Mat4,
-      #[doc = " size: 64, offset: 0x40, type: `mat4x4<f32>`"]
+      #[doc = "offset: 64, size: 64, type: `mat4x4<f32>`"]
       pub inverse_transpose_model: glam::Mat4,
-      #[doc = " size: 4, offset: 0x80, type: `u32`"]
+      #[doc = "offset: 128, size: 4, type: `u32`"]
       pub flags: u32,
       pub _pad_flags: [u8; 0xC],
     }
@@ -722,7 +722,7 @@ pub mod bevy_pbr {
       pub flags: u32,
     }
     impl MeshInit {
-      pub const fn build(&self) -> Mesh {
+      pub fn build(&self) -> Mesh {
         Mesh {
           model: self.model,
           inverse_transpose_model: self.inverse_transpose_model,

--- a/wgsl_bindgen/tests/snapshots/main_bindgen.snap
+++ b/wgsl_bindgen/tests/snapshots/main_bindgen.snap
@@ -240,9 +240,9 @@ pub mod basic {
     #[repr(C, align(256))]
     #[derive(Debug, PartialEq, Clone, Copy)]
     pub struct Style {
-      #[doc = " size: 16, offset: 0x0, type: `vec4<f32>`"]
+      #[doc = "offset: 0, size: 16, type: `vec4<f32>`"]
       pub color: glam::Vec4,
-      #[doc = " size: 4, offset: 0x10, type: `f32`"]
+      #[doc = "offset: 16, size: 4, type: `f32`"]
       pub width: f32,
       pub _pad_width: [u8; 0xC],
     }
@@ -262,7 +262,7 @@ pub mod basic {
       pub width: f32,
     }
     impl StyleInit {
-      pub const fn build(&self) -> Style {
+      pub fn build(&self) -> Style {
         Style {
           color: self.color,
           width: self.width,

--- a/wgsl_bindgen/tests/snapshots/module_path_binding_generation.snap
+++ b/wgsl_bindgen/tests/snapshots/module_path_binding_generation.snap
@@ -94,11 +94,11 @@ pub mod lines {
     #[repr(C, align(16))]
     #[derive(Debug, PartialEq, Clone, Copy)]
     pub struct SegmentData {
-      #[doc = " size: 8, offset: 0x0, type: `vec2<f32>`"]
+      #[doc = "offset: 0, size: 8, type: `vec2<f32>`"]
       pub start: glam::Vec2,
-      #[doc = " size: 8, offset: 0x8, type: `vec2<f32>`"]
+      #[doc = "offset: 8, size: 8, type: `vec2<f32>`"]
       pub end: glam::Vec2,
-      #[doc = " size: 16, offset: 0x10, type: `vec4<f32>`"]
+      #[doc = "offset: 16, size: 16, type: `vec4<f32>`"]
       pub color: glam::Vec4,
     }
     impl SegmentData {

--- a/wgsl_bindgen/tests/snapshots/relative_path_bindgen.snap
+++ b/wgsl_bindgen/tests/snapshots/relative_path_bindgen.snap
@@ -240,9 +240,9 @@ pub mod tests {
         #[repr(C, align(16))]
         #[derive(Debug, PartialEq, Clone, Copy)]
         pub struct Style {
-          #[doc = " size: 16, offset: 0x0, type: `vec4<f32>`"]
+          #[doc = "offset: 0, size: 16, type: `vec4<f32>`"]
           pub color: glam::Vec4,
-          #[doc = " size: 4, offset: 0x10, type: `f32`"]
+          #[doc = "offset: 16, size: 4, type: `f32`"]
           pub width: f32,
           pub _pad_width: [u8; 0xC],
         }
@@ -262,7 +262,7 @@ pub mod tests {
           pub width: f32,
         }
         impl StyleInit {
-          pub const fn build(&self) -> Style {
+          pub fn build(&self) -> Style {
             Style {
               color: self.color,
               width: self.width,

--- a/wgsl_bindgen/tests/snapshots/struct_alignment_minimal.snap
+++ b/wgsl_bindgen/tests/snapshots/struct_alignment_minimal.snap
@@ -81,9 +81,9 @@ pub mod minimal {
   #[repr(C, align(256))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct Uniforms {
-    #[doc = " size: 16, offset: 0x0, type: `vec4<f32>`"]
+    #[doc = "offset: 0, size: 16, type: `vec4<f32>`"]
     pub color: glam::Vec4,
-    #[doc = " size: 4, offset: 0x10, type: `f32`"]
+    #[doc = "offset: 16, size: 4, type: `f32`"]
     pub width: f32,
     pub _pad_width: [u8; 0xC],
   }
@@ -103,7 +103,7 @@ pub mod minimal {
     pub width: f32,
   }
   impl UniformsInit {
-    pub const fn build(&self) -> Uniforms {
+    pub fn build(&self) -> Uniforms {
       Uniforms {
         color: self.color,
         width: self.width,

--- a/wgsl_bindgen/tests/snapshots/struct_alignment_padding.snap
+++ b/wgsl_bindgen/tests/snapshots/struct_alignment_padding.snap
@@ -81,9 +81,9 @@ pub mod padding {
   #[repr(C, align(16))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct Style {
-    #[doc = " size: 16, offset: 0x0, type: `vec4<f32>`"]
+    #[doc = "offset: 0, size: 16, type: `vec4<f32>`"]
     pub color: glam::Vec4,
-    #[doc = " size: 4, offset: 0x10, type: `f32`"]
+    #[doc = "offset: 16, size: 4, type: `f32`"]
     pub width: f32,
     pub _pad_width: [u8; 0x4],
     pub _padding: [u8; 0x8],
@@ -105,7 +105,7 @@ pub mod padding {
     pub width: f32,
   }
   impl StyleInit {
-    pub const fn build(&self) -> Style {
+    pub fn build(&self) -> Style {
       Style {
         color: self.color,
         width: self.width,

--- a/wgsl_bindgen/tests/snapshots/struct_layouts.snap
+++ b/wgsl_bindgen/tests/snapshots/struct_layouts.snap
@@ -140,11 +140,11 @@ pub mod layouts {
   #[repr(C, align(4))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct Scalars {
-    #[doc = " size: 4, offset: 0x0, type: `u32`"]
+    #[doc = "offset: 0, size: 4, type: `u32`"]
     pub a: u32,
-    #[doc = " size: 4, offset: 0x4, type: `i32`"]
+    #[doc = "offset: 4, size: 4, type: `i32`"]
     pub b: i32,
-    #[doc = " size: 4, offset: 0x8, type: `f32`"]
+    #[doc = "offset: 8, size: 4, type: `f32`"]
     pub c: f32,
     pub _pad_d: [u8; 0x4],
   }
@@ -166,7 +166,7 @@ pub mod layouts {
     pub c: f32,
   }
   impl ScalarsInit {
-    pub const fn build(&self) -> Scalars {
+    pub fn build(&self) -> Scalars {
       Scalars {
         a: self.a,
         b: self.b,
@@ -183,15 +183,15 @@ pub mod layouts {
   #[repr(C, align(16))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct VectorsU32 {
-    #[doc = " size: 8, offset: 0x0, type: `vec2<u32>`"]
+    #[doc = "offset: 0, size: 8, type: `vec2<u32>`"]
     pub a: glam::UVec2,
     pub _pad_a: [u8; 0x8],
-    #[doc = " size: 12, offset: 0x10, type: `vec3<u32>`"]
+    #[doc = "offset: 16, size: 12, type: `vec3<u32>`"]
     pub b: glam::UVec3,
     pub _pad_b: [u8; 0x4],
-    #[doc = " size: 16, offset: 0x20, type: `vec4<u32>`"]
+    #[doc = "offset: 32, size: 16, type: `vec4<u32>`"]
     pub c: glam::UVec4,
-    #[doc = " size: 4, offset: 0x30, type: `f32`"]
+    #[doc = "offset: 48, size: 4, type: `f32`"]
     pub _padding: f32,
     pub _pad__padding: [u8; 0xC],
   }
@@ -222,7 +222,7 @@ pub mod layouts {
     pub _padding: f32,
   }
   impl VectorsU32Init {
-    pub const fn build(&self) -> VectorsU32 {
+    pub fn build(&self) -> VectorsU32 {
       VectorsU32 {
         a: self.a,
         _pad_a: [0; 0x8],
@@ -242,13 +242,13 @@ pub mod layouts {
   #[repr(C, align(16))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct VectorsI32 {
-    #[doc = " size: 8, offset: 0x0, type: `vec2<i32>`"]
+    #[doc = "offset: 0, size: 8, type: `vec2<i32>`"]
     pub a: glam::IVec2,
     pub _pad_a: [u8; 0x8],
-    #[doc = " size: 12, offset: 0x10, type: `vec3<i32>`"]
+    #[doc = "offset: 16, size: 12, type: `vec3<i32>`"]
     pub b: glam::IVec3,
     pub _pad_b: [u8; 0x4],
-    #[doc = " size: 16, offset: 0x20, type: `vec4<i32>`"]
+    #[doc = "offset: 32, size: 16, type: `vec4<i32>`"]
     pub c: glam::IVec4,
   }
   impl VectorsI32 {
@@ -270,7 +270,7 @@ pub mod layouts {
     pub c: glam::IVec4,
   }
   impl VectorsI32Init {
-    pub const fn build(&self) -> VectorsI32 {
+    pub fn build(&self) -> VectorsI32 {
       VectorsI32 {
         a: self.a,
         _pad_a: [0; 0x8],
@@ -288,13 +288,13 @@ pub mod layouts {
   #[repr(C, align(16))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct VectorsF32 {
-    #[doc = " size: 8, offset: 0x0, type: `vec2<f32>`"]
+    #[doc = "offset: 0, size: 8, type: `vec2<f32>`"]
     pub a: glam::Vec2,
     pub _pad_a: [u8; 0x8],
-    #[doc = " size: 12, offset: 0x10, type: `vec3<f32>`"]
+    #[doc = "offset: 16, size: 12, type: `vec3<f32>`"]
     pub b: glam::Vec3,
     pub _pad_b: [u8; 0x4],
-    #[doc = " size: 16, offset: 0x20, type: `vec4<f32>`"]
+    #[doc = "offset: 32, size: 16, type: `vec4<f32>`"]
     pub c: glam::Vec4,
   }
   impl VectorsF32 {
@@ -316,7 +316,7 @@ pub mod layouts {
     pub c: glam::Vec4,
   }
   impl VectorsF32Init {
-    pub const fn build(&self) -> VectorsF32 {
+    pub fn build(&self) -> VectorsF32 {
       VectorsF32 {
         a: self.a,
         _pad_a: [0; 0x8],
@@ -334,24 +334,24 @@ pub mod layouts {
   #[repr(C, align(16))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct MatricesF32 {
-    #[doc = " size: 64, offset: 0x0, type: `mat4x4<f32>`"]
+    #[doc = "offset: 0, size: 64, type: `mat4x4<f32>`"]
     pub a: glam::Mat4,
-    #[doc = " size: 64, offset: 0x40, type: `mat4x3<f32>`"]
+    #[doc = "offset: 64, size: 64, type: `mat4x3<f32>`"]
     pub b: [[f32; 4]; 4],
-    #[doc = " size: 32, offset: 0x80, type: `mat4x2<f32>`"]
+    #[doc = "offset: 128, size: 32, type: `mat4x2<f32>`"]
     pub c: [[f32; 2]; 4],
-    #[doc = " size: 48, offset: 0xA0, type: `mat3x4<f32>`"]
+    #[doc = "offset: 160, size: 48, type: `mat3x4<f32>`"]
     pub d: [[f32; 4]; 3],
-    #[doc = " size: 48, offset: 0xD0, type: `mat3x3<f32>`"]
+    #[doc = "offset: 208, size: 48, type: `mat3x3<f32>`"]
     pub e: glam::Mat3A,
-    #[doc = " size: 24, offset: 0x100, type: `mat3x2<f32>`"]
+    #[doc = "offset: 256, size: 24, type: `mat3x2<f32>`"]
     pub f: [[f32; 2]; 3],
     pub _pad_f: [u8; 0x8],
-    #[doc = " size: 32, offset: 0x120, type: `mat2x4<f32>`"]
+    #[doc = "offset: 288, size: 32, type: `mat2x4<f32>`"]
     pub g: [[f32; 4]; 2],
-    #[doc = " size: 32, offset: 0x140, type: `mat2x3<f32>`"]
+    #[doc = "offset: 320, size: 32, type: `mat2x3<f32>`"]
     pub h: [[f32; 4]; 2],
-    #[doc = " size: 16, offset: 0x160, type: `mat2x2<f32>`"]
+    #[doc = "offset: 352, size: 16, type: `mat2x2<f32>`"]
     pub i: glam::Mat2,
   }
   impl MatricesF32 {
@@ -394,7 +394,7 @@ pub mod layouts {
     pub i: glam::Mat2,
   }
   impl MatricesF32Init {
-    pub const fn build(&self) -> MatricesF32 {
+    pub fn build(&self) -> MatricesF32 {
       MatricesF32 {
         a: self.a,
         b: self.b,
@@ -417,13 +417,13 @@ pub mod layouts {
   #[repr(C, align(16))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct StaticArrays {
-    #[doc = " size: 20, offset: 0x0, type: `array<u32, 5>`"]
+    #[doc = "offset: 0, size: 20, type: `array<u32, 5>`"]
     pub a: [u32; 5],
-    #[doc = " size: 12, offset: 0x14, type: `array<f32, 3>`"]
+    #[doc = "offset: 20, size: 12, type: `array<f32, 3>`"]
     pub b: [f32; 3],
-    #[doc = " size: 32768, offset: 0x20, type: `array<mat4x4<f32>, 512>`"]
+    #[doc = "offset: 32, size: 32768, type: `array<mat4x4<f32>, 512>`"]
     pub c: [glam::Mat4; 512],
-    #[doc = " size: 64, offset: 0x8020, type: `array<vec3<f32>, 4>`"]
+    #[doc = "offset: 32800, size: 64, type: `array<vec3<f32>, 4>`"]
     pub d: [(glam::Vec3, [u8; 0x4]); 4],
   }
   impl StaticArrays {
@@ -436,12 +436,35 @@ pub mod layouts {
       Self { a, b, c, d }
     }
   }
+  #[repr(C)]
+  #[derive(Debug, PartialEq, Clone, Copy)]
+  pub struct StaticArraysInit {
+    pub a: [u32; 5],
+    pub b: [f32; 3],
+    pub c: [glam::Mat4; 512],
+    pub d: [glam::Vec3; 4],
+  }
+  impl StaticArraysInit {
+    pub fn build(&self) -> StaticArrays {
+      StaticArrays {
+        a: self.a,
+        b: self.b,
+        c: self.c,
+        d: self.d.map(|elem| (elem, [0u8; 4])),
+      }
+    }
+  }
+  impl From<StaticArraysInit> for StaticArrays {
+    fn from(data: StaticArraysInit) -> Self {
+      data.build()
+    }
+  }
   #[repr(C, align(16))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct Nested {
-    #[doc = " size: 368, offset: 0x0, type: `MatricesF32`"]
+    #[doc = "offset: 0, size: 368, type: `MatricesF32`"]
     pub a: MatricesF32,
-    #[doc = " size: 48, offset: 0x170, type: `VectorsF32`"]
+    #[doc = "offset: 368, size: 48, type: `VectorsF32`"]
     pub b: VectorsF32,
   }
   impl Nested {
@@ -452,9 +475,9 @@ pub mod layouts {
   #[repr(C, align(16))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct Uniforms {
-    #[doc = " size: 16, offset: 0x0, type: `vec4<f32>`"]
+    #[doc = "offset: 0, size: 16, type: `vec4<f32>`"]
     pub color_rgb: glam::Vec4,
-    #[doc = " size: 16, offset: 0x10, type: `Scalars`"]
+    #[doc = "offset: 16, size: 16, type: `Scalars`"]
     pub scalars: Scalars,
   }
   impl Uniforms {

--- a/wgsl_bindgen/tests/snapshots/vec3a_padding_overflow_issue.snap
+++ b/wgsl_bindgen/tests/snapshots/vec3a_padding_overflow_issue.snap
@@ -85,15 +85,15 @@ pub mod vec3a_padding_issue {
   #[repr(C, align(16))]
   #[derive(Debug, PartialEq, Clone, Copy)]
   pub struct Job {
-    #[doc = " size: 12, offset: 0x0, type: `vec3<f32>`"]
+    #[doc = "offset: 0, size: 12, type: `vec3<f32>`"]
     pub position: glam::Vec3,
     pub _pad_position: [u8; 0x4],
-    #[doc = " size: 12, offset: 0x10, type: `vec3<f32>`"]
+    #[doc = "offset: 16, size: 12, type: `vec3<f32>`"]
     pub direction: glam::Vec3,
     pub _pad_direction: [u8; 0x4],
-    #[doc = " size: 12, offset: 0x20, type: `vec3<f32>`"]
+    #[doc = "offset: 32, size: 12, type: `vec3<f32>`"]
     pub accum: glam::Vec3,
-    #[doc = " size: 4, offset: 0x2C, type: `u32`"]
+    #[doc = "offset: 44, size: 4, type: `u32`"]
     pub depth: u32,
   }
   impl Job {
@@ -122,7 +122,7 @@ pub mod vec3a_padding_issue {
     pub depth: u32,
   }
   impl JobInit {
-    pub const fn build(&self) -> Job {
+    pub fn build(&self) -> Job {
       Job {
         position: self.position,
         _pad_position: [0; 0x4],


### PR DESCRIPTION
Summary

  This PR introduces two significant enhancements to WGSL binding generation that improve both developer ergonomics and code readability:

  1. Init Struct Generation for Arrays with Tuple Padding: Automatically generates user-friendly Init structs for types containing arrays with tuple padding
  2. Improved Field Documentation Format: Updates struct field documentation to use a more readable format with decimal offsets