### PR TITLE
docs: fix typo (Seperate->Separate (x1))

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ bind_group.set(&mut render_pass); // Simple, safe usage
     )?;
     ```
 
--   Shader registry utility to dynamically call `create_shader` variants depending on the variant. This is useful when trying to keep cache of entry to shader modules. Also remember to add shader defines to accomodate for different permutation of the shader modules.
+-   Shader registry utility to dynamically call `create_shader` variants depending on the variant. This is useful when trying to keep cache of entry to shader modules. Also remember to add shader defines to accommodate for different permutation of the shader modules.
 -   Ability to add additional scan directories for shader imports when defining the workflow.
 
 ### Type Handling:

--- a/TODO.md
+++ b/TODO.md
@@ -28,6 +28,6 @@
   - https://www.reddit.com/r/rust/comments/16e18kp/how_to_set_alignment_of_individual_struct_members/
 
 * Add a way to encode variant types in wgsl?. 
-  * Maybe a seperate binary that accepts rust source. 
+  * Maybe a separate binary that accepts rust source. 
   * Generates accessors, setters in wgsl
   * Struct fields are efficiently utilised.

--- a/wgsl_bindgen/CHANGELOG.md
+++ b/wgsl_bindgen/CHANGELOG.md
@@ -251,7 +251,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Adjust size if custom alignment is specified. ([`a4b61c7`](https://github.com/Swoorup/wgsl-bindgen/commit/a4b61c7d52496499b92b029a3604053d2420b147))
     - Ability to override alignment for structs ([`cd26b91`](https://github.com/Swoorup/wgsl-bindgen/commit/cd26b91be29870ac629a1674a8a43ba98d46b6d6))
     - Use Result type for create_shader* when using `NagaOilComposer` ([`80a7f95`](https://github.com/Swoorup/wgsl-bindgen/commit/80a7f9594330b6e982bb91bb12991df8b79cba70))
-    - Seperate types, assertions, impls in generated output ([`c2c4dc9`](https://github.com/Swoorup/wgsl-bindgen/commit/c2c4dc956925aedef11d706cd7024c8b25593a66))
+    - Separate types, assertions, impls in generated output ([`c2c4dc9`](https://github.com/Swoorup/wgsl-bindgen/commit/c2c4dc956925aedef11d706cd7024c8b25593a66))
     - RustSourceItem => RustItem ([`ce2a91e`](https://github.com/Swoorup/wgsl-bindgen/commit/ce2a91eca61507ba237fd9828a84a5d00a6e2d99))
     - Pass entry point name to builders ([`4fc895b`](https://github.com/Swoorup/wgsl-bindgen/commit/4fc895bef6ce8a29b32611fc363ea68a40b60405))
     - Export quote, syn functions and macros ([`782f481`](https://github.com/Swoorup/wgsl-bindgen/commit/782f481c70bb5d8ae8381c0ddf83ec4ddc6a2a79))


### PR DESCRIPTION
## Summary
Fixes spelling/typo issues found in this project's documentation.

**Details:** Fix documentation typos: Seperate->Separate (x1); seperate->separate (x1); accomodate->accommodate (x1)

**Files:**
- `CHANGELOG.md`
- `TODO.md`
- `README.md`

Documentation-only; no functional code changes.
